### PR TITLE
fix float64/string value conversion issue with config

### DIFF
--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -279,6 +279,9 @@ func recordMapValueToString(configMap map[string]interface{}) map[string]interfa
 				config[configKey] = "0"
 			}
 			break
+		case float64:
+			config[configKey] = strconv.FormatFloat(configValue.(float64), 'f', -1, 64)
+			break
 		default:
 			config[configKey] = configValue
 		}


### PR DESCRIPTION
convert float64 values in config maps to string as sometimes NS1 api will return a numeric value as a number and sometimes as a string
fixes #132 

I have validated that when the value arrives as numeric and we push an update that has the value as a string the NS1 api does the correct thing.