### PR TITLE
upgrade go-ns1 to 2.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/ns1/ns1-go.v2 v2.3.0
+	gopkg.in/ns1/ns1-go.v2 v2.4.2
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
-gopkg.in/ns1/ns1-go.v2 v2.3.0 h1:do9yiDbSfrxpqEnsxBmpxA2DC0fMcRobdXUmI2K+Fkw=
-gopkg.in/ns1/ns1-go.v2 v2.3.0/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
+gopkg.in/ns1/ns1-go.v2 v2.4.2 h1:H6VnvLez0GjxXsXat6MUFmKuiMFuDaMBdGF9qtkmODo=
+gopkg.in/ns1/ns1-go.v2 v2.4.2/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	clientVersion = "2.3.0"
+	clientVersion = "2.4.2"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/data/meta.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/data/meta.go
@@ -129,6 +129,12 @@ type Meta struct {
 	// Values between 0 and 100 are recommended for simplicity's sake.
 	// float64 or FeedPtr.
 	Weight interface{} `json:"weight,omitempty"`
+	
+	// Indicates a cost.
+	// Filters that use costs normalize them.
+	// Any positive values are allowed.
+	// float64 or FeedPtr.
+	Cost interface{} `json:"cost,omitempty"`
 
 	// Indicates a "low watermark" to use for load shedding.
 	// The value should depend on the metric used to determine
@@ -527,6 +533,10 @@ var validationMap = map[string]metaValidation{
 	"Weight": {kinds(reflect.Float64, reflect.Int), checkFuncs(
 		func(v reflect.Value) error {
 			return validatePositiveNumber("Weight", v)
+		})},
+	"Cost": {kinds(reflect.Float64, reflect.Int), checkFuncs(
+		func(v reflect.Value) error {
+			return validatePositiveNumber("Cost", v)
 		})},
 	"LowWatermark":  {kinds(reflect.Int), nil},
 	"HighWatermark": {kinds(reflect.Int), nil},

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/zone.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/zone.go
@@ -22,7 +22,7 @@ func (s *ZonesService) List() ([]*dns.Zone, *http.Response, error) {
 
 	zl := []*dns.Zone{}
 	var resp *http.Response
-	if s.client.FollowPagination == true {
+	if s.client.FollowPagination {
 		resp, err = s.client.DoWithPagination(req, &zl, s.nextZones)
 	} else {
 		resp, err = s.client.Do(req, &zl)
@@ -47,7 +47,7 @@ func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
 
 	var z dns.Zone
 	var resp *http.Response
-	if s.client.FollowPagination == true {
+	if s.client.FollowPagination {
 		resp, err = s.client.DoWithPagination(req, &z, s.nextRecords)
 	} else {
 		resp, err = s.client.Do(req, &z)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -358,7 +358,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
-# gopkg.in/ns1/ns1-go.v2 v2.3.0
+# gopkg.in/ns1/ns1-go.v2 v2.4.2
 gopkg.in/ns1/ns1-go.v2/rest
 gopkg.in/ns1/ns1-go.v2/rest/model/account
 gopkg.in/ns1/ns1-go.v2/rest/model/data


### PR DESCRIPTION
Hi,
There is need to upgrade go-ns1 to 2.4.2 in order to support `cost` field inside answers meta