### PR TITLE
Add ns1_record data source

### DIFF
--- a/ns1/data_source_record.go
+++ b/ns1/data_source_record.go
@@ -1,0 +1,118 @@
+package ns1
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
+)
+
+func dataSourceRecord() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"zone": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"meta": {
+				Type:             schema.TypeMap,
+				Optional:         true,
+				DiffSuppressFunc: metaDiffSuppressUp,
+			},
+			"link": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"use_client_subnet": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"short_answers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"answers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"answer": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"meta": {
+							Type:             schema.TypeMap,
+							Optional:         true,
+							DiffSuppressFunc: metaDiffSuppress,
+						},
+					},
+				},
+			},
+			"regions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"meta": {
+							Type:             schema.TypeMap,
+							Optional:         true,
+							DiffSuppressFunc: metaDiffSuppress,
+						},
+					},
+				},
+			},
+			"filters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"filter": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"disabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"config": {
+							Type:     schema.TypeMap,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+		Read: dataSourceRecordRead,
+	}
+}
+
+func dataSourceRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ns1.Client)
+
+	r, _, err := client.Records.Get(d.Get("zone").(string), d.Get("domain").(string), d.Get("type").(string))
+	if err != nil {
+		return err
+	}
+
+	return recordToResourceData(d, r)
+}

--- a/ns1/data_source_record.go
+++ b/ns1/data_source_record.go
@@ -2,7 +2,6 @@ package ns1
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
 )
 
 func dataSourceRecord() *schema.Resource {
@@ -22,97 +21,82 @@ func dataSourceRecord() *schema.Resource {
 			},
 			"ttl": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
 			},
 			"meta": {
-				Type:             schema.TypeMap,
-				Optional:         true,
-				DiffSuppressFunc: metaDiffSuppressUp,
+				Type:     schema.TypeMap,
+				Computed: true,
 			},
 			"link": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 			"use_client_subnet": {
 				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
 			},
 			"short_answers": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"answers": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"answer": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Computed: true,
 						},
 						"region": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Computed: true,
 						},
 						"meta": {
-							Type:             schema.TypeMap,
-							Optional:         true,
-							DiffSuppressFunc: metaDiffSuppress,
+							Type:     schema.TypeMap,
+							Computed: true,
 						},
 					},
 				},
 			},
 			"regions": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:     schema.TypeString,
-							Required: true,
+							Computed: true,
 						},
 						"meta": {
-							Type:             schema.TypeMap,
-							Optional:         true,
-							DiffSuppressFunc: metaDiffSuppress,
+							Type:     schema.TypeMap,
+							Computed: true,
 						},
 					},
 				},
 			},
 			"filters": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"filter": {
 							Type:     schema.TypeString,
-							Required: true,
+							Computed: true,
 						},
 						"disabled": {
 							Type:     schema.TypeBool,
-							Optional: true,
+							Computed: true,
 						},
 						"config": {
 							Type:     schema.TypeMap,
-							Optional: true,
+							Computed: true,
 						},
 					},
 				},
 			},
 		},
-		Read: dataSourceRecordRead,
+		Read: RecordRead,
 	}
-}
-
-func dataSourceRecordRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ns1.Client)
-
-	r, _, err := client.Records.Get(d.Get("zone").(string), d.Get("domain").(string), d.Get("type").(string))
-	if err != nil {
-		return err
-	}
-
-	return recordToResourceData(d, r)
 }

--- a/ns1/data_source_record_test.go
+++ b/ns1/data_source_record_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceRecord(t *testing.T) {
 	rString := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 	zoneName := fmt.Sprintf("terraform-test-%s.io", rString)
 	domainName := fmt.Sprintf("test.%s", zoneName)
-	rrType := "CNAME"
+	rrType := "A"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -30,6 +30,9 @@ func TestAccDataSourceRecord(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "zone", zoneName),
 					resource.TestCheckResourceAttr(dataSourceName, "domain", domainName),
 					resource.TestCheckResourceAttr(dataSourceName, "type", rrType),
+					testAccCheckRecordAnswerRdata(
+						t, &record, 0, []string{"1.2.3.4"},
+					),
 				),
 			},
 		},
@@ -41,6 +44,10 @@ func testAccDataSourceResource(zoneName string, domainName string, rrType string
   zone = "%s"
   domain = "%s"
   type = "%s"
+
+  answers {
+    answer = "1.2.3.4"
+  }
 }
 
 data "ns1_record" "test" {

--- a/ns1/data_source_record_test.go
+++ b/ns1/data_source_record_test.go
@@ -1,0 +1,52 @@
+package ns1
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+func TestAccDataSourceRecord(t *testing.T) {
+	var record dns.Record
+	dataSourceName := "data.ns1_record.test"
+	rString := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	zoneName := fmt.Sprintf("terraform-test-%s.io", rString)
+	domainName := fmt.Sprintf("test.%s", zoneName)
+	rrType := "CNAME"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceResource(zoneName, domainName, rrType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordExists("ns1_record.it", &record),
+					resource.TestCheckResourceAttr(dataSourceName, "zone", zoneName),
+					resource.TestCheckResourceAttr(dataSourceName, "domain", domainName),
+					resource.TestCheckResourceAttr(dataSourceName, "type", rrType),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceResource(zoneName string, domainName string, rrType string) string {
+	return fmt.Sprintf(`resource "ns1_record" "it" {
+  zone = "%s"
+  domain = "%s"
+  type = "%s"
+}
+
+data "ns1_record" "test" {
+  zone = "${ns1_record.it.zone}"
+  domain = "${ns1_record.it.domain}"
+  type = "${ns1_record.it.type}"
+}
+`, zoneName, domainName, rrType)
+}

--- a/ns1/provider.go
+++ b/ns1/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"ns1_zone":   dataSourceZone(),
 			"ns1_dnssec": dataSourceDNSSEC(),
+			"ns1_record": dataSourceRecord(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"ns1_zone":          resourceZone(),

--- a/website/docs/d/record.html.markdown
+++ b/website/docs/d/record.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "ns1"
+page_title: "NS1: ns1_record"
+sidebar_current: "docs-ns1-datasource-record"
+description: |-
+  Provides details about a NS1 Record.
+---
+
+# Data Source: ns1_record
+
+Provides details about a NS1 Record. Use this if you would simply like to read
+information from NS1 into your configurations. For read/write operations, you
+should use a resource.
+
+## Example Usage
+
+```hcl
+# Get details about a NS1 Record.
+data "ns1_record" "example" {
+  zone   = "example.io"
+  domain = "terraform.example.io"
+  type   = "A"
+}
+```
+
+## Argument Reference
+
+* `zone` - (Required) The zone the record belongs to.
+* `domain` - (Required) The records' domain.
+* `type` - (Required) The records' RR type.
+
+## Attributes Reference
+
+In addition to the argument above, the following are exported:
+
+* `ttl` - The records' time to live (in seconds).
+* `link` - The target record this links to.
+* `use_client_subnet` - Whether to use EDNS client subnet data when available(in filter chain).
+* ` meta` - Map of metadata
+* `regions` - List of regions.
+* `answers` - List of NS1 answers.
+* `filters` - List of NS1 filters.

--- a/website/docs/d/record.html.markdown
+++ b/website/docs/d/record.html.markdown
@@ -35,8 +35,8 @@ In addition to the argument above, the following are exported:
 
 * `ttl` - The records' time to live (in seconds).
 * `link` - The target record this links to.
-* `use_client_subnet` - Whether to use EDNS client subnet data when available(in filter chain).
-* ` meta` - Map of metadata
+* `use_client_subnet` - Whether to use EDNS client subnet data when available (in filter chain).
+* `meta` - Map of metadata
 * `regions` - List of regions.
 * `answers` - List of NS1 answers.
 * `filters` - List of NS1 filters.


### PR DESCRIPTION
PR to add an `ns1_record` data source.

Local Testing Output

Terraform
```
data "ns1_zone" "za-test" {
  zone = "za.test"
}

data "ns1_record" "abc" {
  zone = data.ns1_zone.za-test.zone
  domain = "abc.${data.ns1_zone.za-test.zone}"
  type = "CNAME"
}

resource "ns1_record" "xyz" {
  zone = data.ns1_zone.za-test.zone
  domain = "xyz.${data.ns1_zone.za-test.zone}"
  type = "CNAME"

  answers {
    answer = data.ns1_record.abc.domain
    meta = {
      up = true
    }
  }
}

```

Plan Output
```
data.ns1_zone.za-test: Refreshing state...
data.ns1_record.abc: Refreshing state...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ns1_record.xyz will be created
  + resource "ns1_record" "xyz" {
      + domain            = "xyz.za.test"
      + id                = (known after apply)
      + ttl               = (known after apply)
      + type              = "CNAME"
      + use_client_subnet = true
      + zone              = "za.test"

      + answers {
          + answer = "abc.za.test"
          + meta   = {
              + "up" = "true"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ns1_record.xyz: Creating...
ns1_record.xyz: Creation complete after 3s [id=zcxzczxcxzcads]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```