### PR TITLE
Fix key missing on apikey when joined to team

### DIFF
--- a/ns1/resource_apikey.go
+++ b/ns1/resource_apikey.go
@@ -114,6 +114,8 @@ func ApikeyCreate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
+		// Key attribute only avail on initial GET
+		updatedKey.Key = k.Key
 
 		return apikeyToResourceData(d, updatedKey)
 	}

--- a/ns1/resource_apikey_test.go
+++ b/ns1/resource_apikey_test.go
@@ -96,6 +96,29 @@ func TestAccAPIKey_ManualDelete(t *testing.T) {
 	})
 }
 
+func TestAccAPIKey_teamKey(t *testing.T) {
+	var apiKey account.APIKey
+	rString := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("terraform acc test key %s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyPermissionsOnTeam(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAPIKeyExists("ns1_apikey.it", &apiKey),
+					testAccCheckAPIKeyName(&apiKey, name),
+					// ensure Key attribute is populated on create of apikey joined to team
+					resource.TestCheckResourceAttrSet("ns1_apikey.it", "key"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAPIKey_permissions(t *testing.T) {
 	var apiKey account.APIKey
 	rString := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)


### PR DESCRIPTION
There a is a bug where the `key` attribute is empty for an `apikey` resource that is a member of a team.

This is due to the fact that permissions are inherited from teams, so an additional GET was required on create to read the inherited permission state.  However, `key` attribute is only sent from API on the initial creation of the apikey, so the results of the 2nd GET do not include them, and the returned resource data does not include `key`

This PR fixes this issue by adding the `key` attribute received in the initial create back to the results of the 2nd GET, before returning the resource data.