### PR TITLE
PERSONA-180 change ns1 go sdk to a newer version to fix 4XX issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/ns1/ns1-go.v2 v2.5.0
+	gopkg.in/ns1/ns1-go.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -278,14 +278,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
-gopkg.in/ns1/ns1-go.v2 v2.4.4-0.20210303072856-ce15e9803fca h1:ntojTXHnxTAqhXwXptkKmWgIwX5zxjYeKlKZtHnCWTE=
-gopkg.in/ns1/ns1-go.v2 v2.4.4-0.20210303072856-ce15e9803fca/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
-gopkg.in/ns1/ns1-go.v2 v2.4.4 h1:xV/rJE2m8p3IncnwMEFrv36K4NDnRXu4CoIkgq+AZek=
-gopkg.in/ns1/ns1-go.v2 v2.4.4/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
-gopkg.in/ns1/ns1-go.v2 v2.4.5 h1:WQ/xdWlCPOHaWQWNFMy+/5nWTJbFtw2BJVumLhxjfSY=
-gopkg.in/ns1/ns1-go.v2 v2.4.5/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
-gopkg.in/ns1/ns1-go.v2 v2.5.0 h1:NWrRU45I5UD1sR5Xy8o1u3ugpjXCWr5EaL1eGVTukx4=
-gopkg.in/ns1/ns1-go.v2 v2.5.0/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
+gopkg.in/ns1/ns1-go.v2 v2.5.1 h1:yDCffh6bVBQuOUHuikJ2CC3cnMmsu8biEEwtLkpxVSI=
+gopkg.in/ns1/ns1-go.v2 v2.5.1/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	clientVersion = "2.4.4"
+	clientVersion = "2.5.1"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true
@@ -169,13 +169,13 @@ func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	}
 	defer resp.Body.Close()
 
+	rl := parseRate(resp)
+	c.RateLimitFunc(rl)
+
 	err = CheckResponse(resp)
 	if err != nil {
 		return resp, err
 	}
-
-	rl := parseRate(resp)
-	c.RateLimitFunc(rl)
 
 	if v != nil {
 		// Try to unmarshal body into given type using streaming decoder.

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/permissions.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/permissions.go
@@ -62,10 +62,23 @@ type PermissionsMonitoring struct {
 type PermissionsDHCP struct {
 	ManageDHCP bool `json:"manage_dhcp"`
 	ViewDHCP   bool `json:"view_dhcp"`
+	// The fields below are only relevant in DDI v2.5+
+	TagsAllow *[]AuthTag `json:"tags_allow,omitempty"`
+	TagsDeny  *[]AuthTag `json:"tags_deny,omitempty"`
 }
 
 // PermissionsIPAM wraps a User's "permissions.ipam" attribute for DDI.
 type PermissionsIPAM struct {
 	ManageIPAM bool `json:"manage_ipam"`
 	ViewIPAM   bool `json:"view_ipam"`
+	// The fields below are only relevant in DDI v2.5+
+	TagsAllow *[]AuthTag `json:"tags_allow,omitempty"`
+	TagsDeny  *[]AuthTag `json:"tags_deny,omitempty"`
+}
+
+// AuthTag wraps the tags used in "tags_allow" and "tags_deny" in DDI and IPAM permissions in DDI.
+// Tag Names must start with prefix "auth:"
+type AuthTag struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/dns/answer.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/dns/answer.go
@@ -141,6 +141,19 @@ func NewSRVAnswer(priority, weight, port int, target string) *Answer {
 	}
 }
 
+// NewDSAnswer creates an Answer for DS record.
+func NewDSAnswer(key string, algorithm string, t string, digest string) *Answer {
+	return &Answer{
+		Meta: &data.Meta{},
+		Rdata: []string{
+			key,
+			algorithm,
+			t,
+			digest,
+		},
+	}
+}
+
 // NewCAAAnswer creates an Answer for a CAA record.
 func NewCAAAnswer(flag int, tag, value string) *Answer {
 	return &Answer{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -358,7 +358,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
-# gopkg.in/ns1/ns1-go.v2 v2.4.4
+# gopkg.in/ns1/ns1-go.v2 v2.5.1
 gopkg.in/ns1/ns1-go.v2/rest
 gopkg.in/ns1/ns1-go.v2/rest/model/account
 gopkg.in/ns1/ns1-go.v2/rest/model/data


### PR DESCRIPTION
The GO SDK was hitting the rate limit when the HTTP request was returning with errors because the rate limit function was being executed after the HTTP error checking