### PR TITLE
Creating ns1_user with security_manage_global_2fa true even if set to false

### DIFF
--- a/ns1/permissions.go
+++ b/ns1/permissions.go
@@ -345,16 +345,13 @@ func resourceDataToPermissions(d *schema.ResourceData) account.PermissionsMap {
 	if v, ok := d.GetOk("monitoring_view_jobs"); ok {
 		p.Monitoring.ViewJobs = v.(bool)
 	}
+	if p.Security == nil {
+		p.Security = &account.PermissionsSecurity{}
+	}
 	if v, ok := d.GetOk("security_manage_global_2fa"); ok {
-		if p.Security == nil {
-			p.Security = &account.PermissionsSecurity{}
-		}
 		p.Security.ManageGlobal2FA = v.(bool)
 	}
 	if v, ok := d.GetOk("security_manage_active_directory"); ok {
-		if p.Security == nil {
-			p.Security = &account.PermissionsSecurity{}
-		}
 		p.Security.ManageActiveDirectory = v.(bool)
 	}
 	if v, ok := d.GetOk("dhcp_manage_dhcp"); ok {

--- a/ns1/resource_user_test.go
+++ b/ns1/resource_user_test.go
@@ -112,6 +112,18 @@ func TestAccUser_permissions(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccUserSecurityPermissionsNoTeam(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists("ns1_user.u", &user),
+					resource.TestCheckResourceAttr("ns1_user.u", "email", "tf_acc_test_ns1@hashicorp.com"),
+					resource.TestCheckResourceAttr("ns1_user.u", "name", name),
+					resource.TestCheckResourceAttr("ns1_user.u", "username", username),
+					resource.TestCheckResourceAttr("ns1_user.u", "account_manage_account_settings", "false"),
+					resource.TestCheckResourceAttr("ns1_user.u", "account_manage_ip_whitelist", "true"),
+					resource.TestCheckResourceAttr("ns1_user.u", "security_manage_global_2fa", "false"),
+				),
+			},
+			{
 				Config: testAccUserPermissionsOnTeam(rString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists("ns1_user.u", &user),
@@ -667,6 +679,27 @@ resource "ns1_user" "u" {
   }
 
   account_manage_ip_whitelist = true
+}
+`, rString, rString, rString)
+}
+
+func testAccUserSecurityPermissionsNoTeam(rString string) string {
+	return fmt.Sprintf(`resource "ns1_team" "t" {
+  name = "terraform acc test team %s"
+  account_manage_account_settings = true
+}
+
+resource "ns1_user" "u" {
+  name = "terraform acc test user %s"
+  username = "tf_acc_test_user_%s"
+  email = "tf_acc_test_ns1@hashicorp.com"
+
+  notify = {
+    billing = false
+  }
+
+  account_manage_ip_whitelist = true
+  security_manage_global_2fa = false
 }
 `, rString, rString, rString)
 }


### PR DESCRIPTION
Terraform set default value to false, but in some cases **p.Security** was not initialized, so the struct sent in the request didn't have the p.Security default values, so it was using the API default value, which is true.

Even if setting **security_manage_global_2fa = false**, because GetOk returns false if the value is equal to Zero-value, how Bool zero value is false, it never sets **security_manage_global_2fa = false**.
The change forces the p.Security to be initialized if it wasn't and change the permission to true if the parameter is passed. 