### PR TITLE
DAITDS-195 - Terraform Docs: ip_whitelist and ip_whitelist_strict are missing

### DIFF
--- a/website/docs/r/apikey.html.markdown
+++ b/website/docs/r/apikey.html.markdown
@@ -48,8 +48,8 @@ The following arguments are supported:
 
 * `name` - (Required) The free form name of the apikey.
 * `teams` - (Optional) The teams that the apikey belongs to.
-* `ip_whitelist` - (Optional) The IP addresses to whitelist for this key.
-* `ip_whitelist_strict` - (Optional) Sets exclusivity on this IP whitelist.
+* `ip_whitelist` - (Optional) Array of IP addresses/networks to which to grant the API key access.
+* `ip_whitelist_strict` - (Optional) Set to true to restrict access to only those IP addresses and networks listed in the **ip_whitelist** field.
 * `dns_view_zones` - (Optional) Whether the apikey can view the accounts zones.
 * `dns_manage_zones` - (Optional) Whether the apikey can modify the accounts zones.
 * `dns_zones_allow_by_default` - (Optional) If true, enable the `dns_zones_allow` list, otherwise enable the `dns_zones_deny` list.

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -59,7 +59,7 @@ resource "ns1_team" "example2" {
 The following arguments are supported:
 
 * `name` - (Required) The free form name of the team.
-* `ip_whitelist` - (Optional) The IP addresses to whitelist for this key.
+* `ip_whitelist` - (Optional) Array of IP addresses objects to chich to grant the team access. Each object includes a **name** (string), and **values** (array of strings) associated to each "allow" list.
 * `dns_view_zones` - (Optional) Whether the team can view the accounts zones.
 * `dns_manage_zones` - (Optional) Whether the team can modify the accounts zones.
 * `dns_zones_allow_by_default` - (Optional) If true, enable the `dns_zones_allow` list, otherwise enable the `dns_zones_deny` list.

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -57,8 +57,8 @@ The following arguments are supported:
 * `email` - (Required) The email address of the user.
 * `notify` - (Required) Whether or not to notify the user of specified events. Only `billing` is available currently.
 * `teams` - (Required) The teams that the user belongs to.
-* `ip_whitelist` - (Optional) The IP addresses to whitelist for this key.
-* `ip_whitelist_strict` - (Optional) Sets exclusivity on this IP whitelist.
+* `ip_whitelist` - (Optional) Array of IP addresses/networks to which to grant the user access. 
+* `ip_whitelist_strict` - (Optional) Set to true to restrict access to only those IP addresses and networks listed in the **ip_whitelist** field.
 * `dns_view_zones` - (Optional) Whether the user can view the accounts zones.
 * `dns_manage_zones` - (Optional) Whether the user can modify the accounts zones.
 * `dns_zones_allow_by_default` - (Optional) If true, enable the `dns_zones_allow` list, otherwise enable the `dns_zones_deny` list.
@@ -97,5 +97,6 @@ additions.
 ## NS1 Documentation
 
 [User Api Docs](https://ns1.com/api#user)
+
 [Managing user permissions](https://help.ns1.com/hc/en-us/articles/360024409034-Managing-user-permissions)
 


### PR DESCRIPTION
PR about [DAITDS-195 - Terraform Docs: ip_whitelist and ip_whitelist_strict are missing](https://ns1inc.atlassian.net/browse/DAITDS-195).
Got the information from [NS1 API Documentation](https://ns1.com/api).