### PR TITLE
Update job resource data on read

### DIFF
--- a/ns1/resource_pulsar_job.go
+++ b/ns1/resource_pulsar_job.go
@@ -386,7 +386,8 @@ func pulsarJobRead(d *schema.ResourceData, meta interface{}) error {
 
 		return ConvertToNs1Error(resp, err)
 	}
-	if err := resourceDataToPulsarJob(j, d); err != nil {
+	// Set Terraform resource data from the job data we just downloaded
+	if err := pulsarJobToResourceData(d, j); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
When reading resource data from the API, I believe the intent is to update the Terraform resource data. It looks like this one line was doing the opposite, causing Terraform to say there are changes to be applied when there are not because Terraform state was not being written. This was also affecting the result of `terraform import`. If you import a Pulsar job and examine the state file, many of its attributes are `null` which should not be.

### Before

Terraform state after `import`:

```json
{
      "mode": "managed",
      "type": "ns1_pulsarjob",
      "name": "***",
      "provider": "provider[\"registry.terraform.io/ns1-terraform/ns1\"]",
      "instances": [
        {
          "schema_version": 1,
          "attributes": {
            "active": null,
            "app_id": "***",
            "blend_metric_weights": null,
            "community": null,
            "config": null,
            "customer": null,
            "id": "***",
            "job_id": "***",
            "name": null,
            "shared": null,
            "type_id": null,
            "weights": []
          },
          "sensitive_attributes": [],
          "private": "***"
        }
      ]
    }
```

Terraform `plan` output:

```shell
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # ns1_pulsarjob.*** will be updated in-place
  ~ resource "ns1_pulsarjob" "***" {
      + active  = true
      + config  = {
          + "http"          = "true"
          + "https"         = "true"
          + "static_values" = "true"
        }
        id      = "***"
      + name    = "***"
      + shared  = false
      + type_id = "latency"
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### After

Terraform state after `import`:

```json
{
      "mode": "managed",
      "type": "ns1_pulsarjob",
      "name": "***",
      "provider": "provider[\"registry.terraform.io/ns1-terraform/ns1\"]",
      "instances": [
        {
          "schema_version": 1,
          "attributes": {
            "active": true,
            "app_id": "***",
            "blend_metric_weights": null,
            "community": false,
            "config": {
              "http": "true",
              "https": "true",
              "static_values": "true"
            },
            "customer": ***,
            "id": "***",
            "job_id": "***",
            "name": "***",
            "shared": false,
            "type_id": "latency",
            "weights": []
          },
          "sensitive_attributes": [],
          "private": "***"
        }
      ]
    }
```

Terraform `plan` output:

```shell
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```