### PR TITLE
add verification pr_notify

### DIFF
--- a/.github/workflows/pr_notify.yml
+++ b/.github/workflows/pr_notify.yml
@@ -6,6 +6,7 @@ on:
     branches: [master]
 jobs:
   jira_job:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Jira Login


### PR DESCRIPTION
Secrets are not available for pr from fork repository in open source projects, this validation skip this job for Prs from fork repos