### PR TITLE
Make apikey key attribute sensitive

### DIFF
--- a/ns1/resource_apikey.go
+++ b/ns1/resource_apikey.go
@@ -16,8 +16,9 @@ func apikeyResource() *schema.Resource {
 			Required: true,
 		},
 		"key": {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 		"teams": {
 			Type:     schema.TypeList,


### PR DESCRIPTION
The goal is to prevent exposing secrets in TF commmand outputs.
Especially important in CD/CI pipelines for example.