### PR TITLE
Fix subdivision split by dash

### DIFF
--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -642,7 +642,7 @@ func subdivisionConverter(s string) (map[string]interface{}, error) {
 	} else {
 		for _, sub := range subdivisions {
 			sub = strings.Join(strings.Fields(sub), "")
-			subp := strings.Split(sub, "-")
+			subp := strings.SplitN(sub, "-", 2)
 			if len(subp) != 2 {
 				return nil, fmt.Errorf("invalid subdivision format. expecting (\"Country-Subdivision\") got %s", sub)
 			}

--- a/ns1/resource_record_test.go
+++ b/ns1/resource_record_test.go
@@ -110,6 +110,8 @@ func TestAccRecord_meta(t *testing.T) {
 	sub := make(map[string]interface{}, 2)
 	sub["BR"] = []interface{}{"SP", "SC"}
 	sub["DZ"] = []interface{}{"01", "02", "03"}
+	sub["NO"] = []interface{}{"NO-01", "NO-11"}
+	sub["SG"] = []interface{}{"SG-03"}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -156,6 +158,8 @@ func TestAccRecord_meta_with_json(t *testing.T) {
 	sub := make(map[string]interface{}, 2)
 	sub["BR"] = []interface{}{"SP", "SC"}
 	sub["DZ"] = []interface{}{"01", "02", "03"}
+	sub["NO"] = []interface{}{"NO-01", "NO-11"}
+	sub["SG"] = []interface{}{"SG-03"}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -786,7 +790,7 @@ resource "ns1_record" "it" {
 
     meta = {
 	  up = true
-	  subdivisions = "BR-SP,BR-SC,DZ-01,DZ-02,DZ-03"
+	  subdivisions = "BR-SP,BR-SC,DZ-01,DZ-02,DZ-03,NO-NO-01,NO-NO-11,SG-SG-03"
       weight = 5
       ip_prefixes = "3.248.0.0/13,13.248.96.0/24,13.248.113.0/24,13.248.118.0/24,13.248.119.0/24,13.248.121.0/24"
       pulsar = jsonencode([{
@@ -817,7 +821,9 @@ resource "ns1_record" "it" {
 		up = true
 		subdivisions = jsonencode({
 			"BR" = ["SP", "SC"],
-			"DZ" = ["01", "02", "03"]
+			"DZ" = ["01", "02", "03"],
+			"NO" = ["NO-01", "NO-11"],
+			"SG" = ["SG-03"]
 		})
 		weight = 5
 		ip_prefixes = "3.248.0.0/13,13.248.96.0/24,13.248.113.0/24,13.248.118.0/24,13.248.119.0/24,13.248.121.0/24"


### PR DESCRIPTION
Most subdivision have a format "Country-Subdivision" but there are 2 (Norway NO and Singapore SG) that also contains the Country code in the subdivisions resulting in a double country code "Country-Country-Subdivision". 
The code was splitting the string by dashes which was resulting into 3 substring and it was failing.

I don't know why they have different format but the correct fix would be updating the subdivision to have all in the same format. These would cause more problems and will require some DB migrations

In order to fix it quickly we just need to use the splitN and limit to 2 substrings that this PR is addressing

@Zach-Johnson please review this PR