### PR TITLE
TEG-214 / Support to override TTL

### DIFF
--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -208,7 +208,7 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 	d.Set("ttl", r.TTL)
 	if r.Type == "ALIAS" {
 		if r.Override_TTL != nil {
-			err := d.Set("override_ttl", r.Override_TTL)
+			err := d.Set("override_ttl", *r.Override_TTL)
 			if err != nil {
 				return fmt.Errorf("[DEBUG] Error setting override_ttl for: %s, error: %#v", r.Domain, err)
 			}


### PR DESCRIPTION
Terraform plugin actually didn't support override TTL to ALIAS type records.
Added override_ttl in record schema and handled it to be supported only by ALIAS records.
Added acceptance tests related to these changes

A small change had to be done in the ns1-go Client which is used by the terraform-plugin, this change is in the PR#159

@Zach-Johnson could you please review? 