### PR TITLE
Fix `notifylist` Acceptance Tests

### DIFF
--- a/ns1/resource_notifylist.go
+++ b/ns1/resource_notifylist.go
@@ -2,8 +2,9 @@ package ns1
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
 	"gopkg.in/ns1/ns1-go.v2/rest/model/monitor"
@@ -70,13 +71,6 @@ func resourceDataToNotifyList(nl *monitor.NotifyList, d *schema.ResourceData) er
 
 			if config != nil {
 				switch ni["type"].(string) {
-				case "user":
-					user := config["user"]
-					if user != nil {
-						ns[i] = monitor.NewUserNotification(user.(string))
-					} else {
-						return fmt.Errorf("wrong config for user expected user field into config")
-					}
 				case "email":
 					email := config["email"]
 					if email != nil {
@@ -104,14 +98,6 @@ func resourceDataToNotifyList(nl *monitor.NotifyList, d *schema.ResourceData) er
 						ns[i] = monitor.NewPagerDutyNotification(serviceKey.(string))
 					} else {
 						return fmt.Errorf("wrong config for pagerduty expected serviceKey field into config")
-					}
-				case "hipchat":
-					token := config["token"]
-					room := config["room"]
-					if token != nil && room != nil {
-						ns[i] = monitor.NewHipChatNotification(token.(string), room.(string))
-					} else {
-						return fmt.Errorf("wrong config for hipchat expected token and room fields into config")
 					}
 				case "slack":
 					url := config["url"]

--- a/ns1/resource_notifylist_test.go
+++ b/ns1/resource_notifylist_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
@@ -58,7 +57,6 @@ func TestAccNotifyList_updated(t *testing.T) {
 
 func TestAccNotifyList_types(t *testing.T) {
 	var nl monitor.NotifyList
-	rString := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -72,24 +70,10 @@ func TestAccNotifyList_types(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNotifyListHipChat,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNotifyListExists("ns1_notifylist.test_hipchat", &nl),
-					testAccCheckNotifyListName(&nl, "terraform test hipchat"),
-				),
-			},
-			{
 				Config: testAccNotifyListPagerDuty,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotifyListExists("ns1_notifylist.test_pagerduty", &nl),
 					testAccCheckNotifyListName(&nl, "terraform test pagerduty"),
-				),
-			},
-			{
-				Config: testAccNotifyListUser(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNotifyListExists("ns1_notifylist.test_user", &nl),
-					testAccCheckNotifyListName(&nl, "terraform test user"),
 				),
 			},
 		},
@@ -251,18 +235,6 @@ resource "ns1_notifylist" "test_slack" {
   }
 }
 `
-const testAccNotifyListHipChat = `
-resource "ns1_notifylist" "test_hipchat" {
-  name = "terraform test hipchat"
-  notifications {
-    type = "hipchat"
-    config = {
-      token = "tftesttoken"
-      room = "TF Test Room"
-    }
-  }
-}
-`
 const testAccNotifyListPagerDuty = `
 resource "ns1_notifylist" "test_pagerduty" {
   name = "terraform test pagerduty"
@@ -274,25 +246,3 @@ resource "ns1_notifylist" "test_pagerduty" {
   }
 }
 `
-
-func testAccNotifyListUser(rString string) string {
-	return fmt.Sprintf(`resource "ns1_user" "u" {
-  name = "terraform acc test user %[1]s"
-  username = "tf_acc_test_user_%[1]s"
-  email = "tf_acc_test_ns1@hashicorp.com"
-  notify = {
-    billing = true
-  }
-}
-
-resource "ns1_notifylist" "test_user" {
-  name = "terraform test user"
-  notifications {
-    type = "user"
-    config = {
-      user = ns1_user.u.username
-    }
-  }
-}
-`, rString)
-}


### PR DESCRIPTION
The resource was not in sync with the API, specifically both `hipchat` & `user` configs were no longer accepted as per these error messages:
```
        Error: PUT https://api.nsone.net/v1/lists: 400 Input validation failed (Value u'hipchat' for field '<obj>.notify_list[0].type' is not in the enumeration: ['email', 'webhook', 'datafeed', 'slack', 'pagerduty'])
```
```
        Error: PUT https://api.nsone.net/v1/lists: 400 Input validation failed (Value u'user' for field '<obj>.notify_list[0].type' is not in the enumeration: ['email', 'webhook', 'datafeed', 'slack', 'pagerduty'])
```

Therefore, both `hipchat` & `user` config related code has been removed.