### PR TITLE
Fix some Zone acceptance test assertions

### DIFF
--- a/ns1/data_source_zone.go
+++ b/ns1/data_source_zone.go
@@ -1,12 +1,7 @@
 package ns1
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
-	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
 )
 
 func dataSourceZone() *schema.Resource {
@@ -96,33 +91,4 @@ func dataSourceZone() *schema.Resource {
 		},
 		Read: zoneRead,
 	}
-}
-
-func dataSourceZoneToResourceData(d *schema.ResourceData, z *dns.Zone) error {
-	d.SetId(z.ID)
-	d.Set("hostmaster", z.Hostmaster)
-	d.Set("ttl", z.TTL)
-	d.Set("nx_ttl", z.NxTTL)
-	d.Set("refresh", z.Refresh)
-	d.Set("retry", z.Retry)
-	d.Set("expiry", z.Expiry)
-	d.Set("networks", z.NetworkIDs)
-	d.Set("dnssec", z.DNSSEC)
-	d.Set("dns_servers", strings.Join(z.DNSServers[:], ","))
-	d.Set("link", z.Link)
-	if z.Secondary != nil && z.Secondary.Enabled {
-		d.Set("primary", z.Secondary.PrimaryIP)
-		d.Set("additional_primaries", z.Secondary.OtherIPs)
-	}
-	if z.Primary != nil && z.Primary.Enabled {
-		secondaries := make([]map[string]interface{}, 0)
-		for _, secondary := range z.Primary.Secondaries {
-			secondaries = append(secondaries, secondaryToMap(&secondary))
-		}
-		err := d.Set("secondaries", secondaries)
-		if err != nil {
-			return fmt.Errorf("[DEBUG] Error setting secondaries for: %s, error: %#v", z.Zone, err)
-		}
-	}
-	return nil
 }

--- a/ns1/resource_zone_test.go
+++ b/ns1/resource_zone_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAccZone_basic(t *testing.T) {
 	var zone dns.Zone
-	defaultHostmaster := "hostmaster@example.net"
+	defaultHostmaster := "hostmaster@nsone.net"
 	zoneName := fmt.Sprintf(
 		"terraform-test-%s.io",
 		acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum),
@@ -288,7 +288,7 @@ func TestAccZone_dnssec(t *testing.T) {
 
 func TestAccZone_hostmaster(t *testing.T) {
 	var zone dns.Zone
-	defaultHostmaster := "hostmaster@example.net"
+	defaultHostmaster := "hostmaster@nsone.net"
 	zoneHostmaster := "hostmaster@rname.test"
 	zoneName := fmt.Sprintf(
 		"terraform-test-%s.io",


### PR DESCRIPTION
And remove unused function `dataSourceZoneToResourceData`, as this data source uses the function `zoneRead` that lives in the `resource_zone.go` file.