### PR TITLE
add import support for datafeed, datasource, notifylist, and monitoringjob

### DIFF
--- a/ns1/resource_datafeed.go
+++ b/ns1/resource_datafeed.go
@@ -30,10 +30,11 @@ func dataFeedResource() *schema.Resource {
 				Optional: true,
 			},
 		},
-		Create: DataFeedCreate,
-		Read:   DataFeedRead,
-		Update: DataFeedUpdate,
-		Delete: DataFeedDelete,
+		Create:   DataFeedCreate,
+		Read:     DataFeedRead,
+		Update:   DataFeedUpdate,
+		Delete:   DataFeedDelete,
+		Importer: &schema.ResourceImporter{State: dataFeedStateFunc},
 	}
 }
 
@@ -111,7 +112,7 @@ func DataFeedUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-//configAdapterIn adapts the configuration types
+// configAdapterIn adapts the configuration types
 func configAdapterIn(d *schema.ResourceData) error {
 	config := d.Get("config").(map[string]interface{})
 	if config != nil {
@@ -128,7 +129,7 @@ func configAdapterIn(d *schema.ResourceData) error {
 	return nil
 }
 
-//configAdapterOut back the original configuration types
+// configAdapterOut back the original configuration types
 func configAdapterOut(f *data.Feed) {
 	config := f.Config
 	if config != nil {
@@ -139,4 +140,16 @@ func configAdapterOut(f *data.Feed) {
 			f.Config = config
 		}
 	}
+}
+
+func dataFeedStateFunc(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid datafeed specifier.  Expecting 1 slashe (\"datasource_id/datafeed_id\"), got %d", len(parts)-1)
+	}
+
+	d.SetId(parts[1])
+	d.Set("source_id", parts[0])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/ns1/resource_datasource.go
+++ b/ns1/resource_datasource.go
@@ -27,10 +27,11 @@ func dataSourceResource() *schema.Resource {
 				Optional: true,
 			},
 		},
-		Create: DataSourceCreate,
-		Read:   DataSourceRead,
-		Update: DataSourceUpdate,
-		Delete: DataSourceDelete,
+		Create:   DataSourceCreate,
+		Read:     DataSourceRead,
+		Update:   DataSourceUpdate,
+		Delete:   DataSourceDelete,
+		Importer: &schema.ResourceImporter{},
 	}
 }
 

--- a/ns1/resource_monitoringjob.go
+++ b/ns1/resource_monitoringjob.go
@@ -116,10 +116,11 @@ func monitoringJobResource() *schema.Resource {
 				},
 			},
 		},
-		Create: MonitoringJobCreate,
-		Read:   MonitoringJobRead,
-		Update: MonitoringJobUpdate,
-		Delete: MonitoringJobDelete,
+		Create:   MonitoringJobCreate,
+		Read:     MonitoringJobRead,
+		Update:   MonitoringJobUpdate,
+		Delete:   MonitoringJobDelete,
+		Importer: &schema.ResourceImporter{},
 	}
 }
 

--- a/ns1/resource_notifylist.go
+++ b/ns1/resource_notifylist.go
@@ -34,10 +34,11 @@ func notifyListResource() *schema.Resource {
 				},
 			},
 		},
-		Create: NotifyListCreate,
-		Read:   NotifyListRead,
-		Update: NotifyListUpdate,
-		Delete: NotifyListDelete,
+		Create:   NotifyListCreate,
+		Read:     NotifyListRead,
+		Update:   NotifyListUpdate,
+		Delete:   NotifyListDelete,
+		Importer: &schema.ResourceImporter{},
 	}
 }
 

--- a/website/docs/r/datafeed.html.markdown
+++ b/website/docs/r/datafeed.html.markdown
@@ -66,6 +66,10 @@ The following arguments are supported:
 All of the arguments listed above are exported as attributes, with no
 additions.
 
+## Import
+
+`terraform import ns1_datafeed.<name> <datasource_id>/<datafeed_id>`
+
 ## NS1 Documentation
 
 [Datafeed Api Doc](https://ns1.com/api#data-feeds)

--- a/website/docs/r/datasource.html.markdown
+++ b/website/docs/r/datasource.html.markdown
@@ -33,6 +33,10 @@ The following arguments are supported:
 All of the arguments listed above are exported as attributes, with no
 additions.
 
+## Import
+
+`terraform import ns1_datasource.<name> <datasource_id>`
+
 ## NS1 Documentation
 
 [Datasource Api Doc](https://ns1.com/api#data-sources)

--- a/website/docs/r/monitoringjob.html.markdown
+++ b/website/docs/r/monitoringjob.html.markdown
@@ -66,6 +66,10 @@ The following arguments are supported:
 All of the arguments listed above are exported as attributes, with no
 additions.
 
+## Import
+
+`terraform import ns1_monitoringjob.<name> <monitoringjob_id>`
+
 ## NS1 Documentation
 
 [MonitoringJob Api Doc](https://ns1.com/api#monitoring-jobs)

--- a/website/docs/r/notifylist.html.markdown
+++ b/website/docs/r/notifylist.html.markdown
@@ -48,6 +48,10 @@ Notify List Notifiers (`notifications`) support the following:
 All of the arguments listed above are exported as attributes, with no
 additions.
 
+## Import
+
+`terraform import ns1_notifylist.<name> <notifylist_id>`
+
 ## NS1 Documentation
 
 [NotifyList Api Doc](https://ns1.com/api#notification-lists)


### PR DESCRIPTION
This PR adds import support for a few resource types.
* ns1_datasource
* ns1_notifylist
* ns1_monitoringjob
* ns1_datafeed

terraform import ns1_datasource.<name> <datasource_id>
terraform import ns1_notifylist.<name> <notifylist_id>
terraform import ns1_monitoringjob.<name> <monitoringjob_id>
terraform import ns1_datafeed.<name> <datasource_id>/<datafeed_id>
