### PR TITLE
In monitoringjobs, sort regions returned by API alphabetically.

### DIFF
--- a/ns1/examples/monitoringjob.tf
+++ b/ns1/examples/monitoringjob.tf
@@ -3,7 +3,7 @@ resource "ns1_monitoringjob" "it" {
   job_type = "tcp"
   name     = "terraform test"
 
-  regions   = ["lga"]
+  regions   = ["lga","sjc","sin"]
   frequency = 60
 
   config = {

--- a/ns1/resource_monitoringjob.go
+++ b/ns1/resource_monitoringjob.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -129,7 +130,10 @@ func monitoringJobToResourceData(d *schema.ResourceData, r *monitor.Job) error {
 	d.Set("job_type", r.Type)
 	d.Set("active", r.Active)
 	d.Set("mute", r.Mute)
-	d.Set("regions", r.Regions)
+	if len(r.Regions) > 0 {
+		sort.Strings(r.Regions)
+		d.Set("regions", r.Regions)
+	}
 	d.Set("frequency", r.Frequency)
 	d.Set("rapid_recheck", r.RapidRecheck)
 	config := make(map[string]string)

--- a/ns1/resource_monitoringjob_test.go
+++ b/ns1/resource_monitoringjob_test.go
@@ -26,7 +26,7 @@ func TestAccMonitoringJob_basic(t *testing.T) {
 					testAccCheckMonitoringJobExists("ns1_monitoringjob.it", &mj),
 					testAccCheckMonitoringJobName(&mj, "terraform test"),
 					testAccCheckMonitoringJobActive(&mj, true),
-					testAccCheckMonitoringJobRegions(&mj, []string{"lga"}),
+					testAccCheckMonitoringJobRegions(&mj, []string{"lga", "sjc", "sin"}),
 					testAccCheckMonitoringJobType(&mj, "tcp"),
 					testAccCheckMonitoringJobFrequency(&mj, 60),
 					testAccCheckMonitoringJobRapidRecheck(&mj, false),
@@ -46,7 +46,7 @@ func TestAccMonitoringJob_basic(t *testing.T) {
 					testAccCheckMonitoringJobExists("ns1_monitoringjob.it", &mj),
 					testAccCheckMonitoringJobName(&mj, "terraform http test"),
 					testAccCheckMonitoringJobActive(&mj, true),
-					testAccCheckMonitoringJobRegions(&mj, []string{"sjc"}),
+					testAccCheckMonitoringJobRegions(&mj, []string{"lga", "sjc", "sin"}),
 					testAccCheckMonitoringJobType(&mj, "http"),
 					testAccCheckMonitoringJobFrequency(&mj, 60),
 					testAccCheckMonitoringJobRapidRecheck(&mj, false),
@@ -71,7 +71,7 @@ func TestAccMonitoringJob_updated(t *testing.T) {
 					testAccCheckMonitoringJobExists("ns1_monitoringjob.it", &mj),
 					testAccCheckMonitoringJobName(&mj, "terraform test"),
 					testAccCheckMonitoringJobActive(&mj, true),
-					testAccCheckMonitoringJobRegions(&mj, []string{"lga"}),
+					testAccCheckMonitoringJobRegions(&mj, []string{"lga", "sjc", "sin"}),
 					testAccCheckMonitoringJobType(&mj, "tcp"),
 					testAccCheckMonitoringJobFrequency(&mj, 60),
 					testAccCheckMonitoringJobRapidRecheck(&mj, false),
@@ -361,7 +361,7 @@ resource "ns1_monitoringjob" "it" {
   job_type = "tcp"
   name     = "terraform test"
 
-  regions   = ["lga"]
+  regions   = ["sin","sjc","lga"]
   frequency = 60
   mute      = true
 
@@ -383,7 +383,7 @@ resource "ns1_monitoringjob" "it" {
   job_type = "http"
   name     = "terraform http test"
 
-  regions   = ["sjc"]
+  regions   = ["sin","sjc","lga"]
   frequency = 60
   mute      = true
 
@@ -400,7 +400,7 @@ resource "ns1_monitoringjob" "it" {
   name     = "terraform test"
 
   active        = true
-  regions       = ["lga"]
+  regions       = ["sin","sjc","lga"]
   frequency     = 120
   rapid_recheck = true
   policy        = "all"

--- a/website/docs/r/monitoringjob.html.markdown
+++ b/website/docs/r/monitoringjob.html.markdown
@@ -16,7 +16,7 @@ Provides a NS1 Monitoring Job resource. This can be used to create, modify, and 
 resource "ns1_monitoringjob" "uswest_monitor" {
   name          = "uswest"
   active        = true
-  regions       = ["sjc", "sin", "lga"]
+  regions       = ["lga", "sjc", "sin"]
   job_type      = "tcp"
   frequency     = 60
   rapid_recheck = true
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `job_type` - (Required) The type of monitoring job to be run. Refer to the NS1 API documentation (https://ns1.com/api#monitoring-jobs) for supported values which include ping, tcp, dns, http.
 * `active` - (Required) Indicates if the job is active or temporarily disabled.
 * `regions` - (Required) The list of region codes in which to run the monitoring
-  job. See NS1 API docs for supported values.
+  job. See NS1 API docs for supported values. NOTE: order alphabetically by region code.
 * `frequency` - (Required) The frequency, in seconds, at which to run the monitoring job in each region.
 * `rapid_recheck` - (Required) If true, on any apparent state change, the job is quickly re-run after one second to confirm the state change before notification.
 * `policy` - (Required) The policy for determining the monitor's global status


### PR DESCRIPTION
Reference Issue https://github.com/ns1-terraform/terraform-provider-ns1/issues/223

For a monitoringjob resource, sort the regions returned from the API alphabetically.  This will allow users to reliably predict the region ordering in terraform plan and applies.  It will also eliminate changes that simply reorder the regions based on the API's return values.

I have also updated website documentation to note the ordering requirement (similar to what was done for the record resource region attribute).  

Additionally, I updated the tests to include multiple regions.  The resource should be set with an unordered region but the expect values are ordered. 

