### PR TITLE
docs: rename ns1_pulsar_job -> ns1_pulsarjob

### DIFF
--- a/website/docs/r/pulsar_job.html.markdown
+++ b/website/docs/r/pulsar_job.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Pulsar Job resource.
 ---
 
-# ns1\_pulsar\_job
+# ns1\_pulsarjob
 
 Provides a Pulsar job resource. This can be used to create, modify, and delete zones.
 


### PR DESCRIPTION
This change addresses an inconsistency in the docs. The correct name seems to be `ns1_pulsarjob`