### PR TITLE
unquote config.send string to match internal Terraform format

### DIFF
--- a/ns1/resource_monitoringjob.go
+++ b/ns1/resource_monitoringjob.go
@@ -146,6 +146,14 @@ func monitoringJobToResourceData(d *schema.ResourceData, r *monitor.Job) error {
 			} else {
 				config[k] = "false"
 			}
+		} else if k == "send" {
+			unquoted, err := strconv.Unquote(`"` + v.(string) + `"`)
+			if err != nil {
+				log.Printf("[ERROR] send string %v cannot be unquoted (%v), using original value", v.(string), err)
+				config[k] = v.(string)
+			} else {
+				config[k] = unquoted
+			}
 		} else {
 			switch t := v.(type) {
 			case string:


### PR DESCRIPTION
Prevent false differences in the `config.send` string since Terraform seems to expand escape strings like '\r' and '\n' automatically.

The NS1 API converts CR and LF to '\r' and '\n' respectively upon API write. Clients can thus write the `config.send` string either with or without escaped characters.