### PR TITLE
zone acceptance tests tweak

### DIFF
--- a/ns1/resource_zone_test.go
+++ b/ns1/resource_zone_test.go
@@ -183,13 +183,13 @@ func TestAccZone_secondary_to_primary_to_normal(t *testing.T) {
 	// sorted by IP please
 	expected := []*dns.ZoneSecondaryServer{
 		{
-			NetworkIDs: []int{0},
+			NetworkIDs: []int{},
 			IP:         "2.2.2.2",
 			Port:       53,
 			Notify:     false,
 		},
 		{
-			NetworkIDs: []int{0},
+			NetworkIDs: []int{},
 			IP:         "3.3.3.3",
 			Port:       5353,
 			Notify:     true,

--- a/ns1/test_funcs.go
+++ b/ns1/test_funcs.go
@@ -16,18 +16,17 @@ func testAccCheckZoneSecondaries(
 	t *testing.T, z *dns.Zone, idx int, expected *dns.ZoneSecondaryServer,
 ) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		assert.True(t, z.Primary.Enabled)
-
+		assert.Truef(t, z.Primary.Enabled, "primary.enabled: got %v, wanted %v", z.Primary.Enabled, true)
 		secondaries := z.Primary.Secondaries
 		sort.SliceStable(secondaries, func(i, j int) bool {
 			return secondaries[i].IP < secondaries[j].IP
 		})
 		secondary := secondaries[idx]
 
-		assert.Equal(t, expected.IP, secondary.IP)
-		assert.Equal(t, expected.Port, secondary.Port)
-		assert.Equal(t, expected.Notify, secondary.Notify)
-		assert.ElementsMatch(t, expected.NetworkIDs, secondary.NetworkIDs)
+		assert.Equalf(t, expected.IP, secondary.IP, "secondary IP: got %v, wanted %v", secondary.IP, expected.IP)
+		assert.Equalf(t, expected.Port, secondary.Port, "secondary port: got %v, wanted %v", secondary.Port, expected.Port)
+		assert.Equalf(t, expected.Notify, secondary.Notify, "secondary notify: got %v, wanted %v", secondary.Notify, expected.Notify)
+		assert.ElementsMatchf(t, expected.NetworkIDs, secondary.NetworkIDs, "secondary network ID mismatch: got %v, wanted %v", z.Primary.Secondaries[idx], expected)
 
 		return nil
 	}


### PR DESCRIPTION
zone acceptance tests now pass except for known issue deleting zones with TSIG:
```
--- PASS: TestAccZone_basic (3.44s)
=== RUN   TestAccZone_updated
--- PASS: TestAccZone_updated (3.13s)
=== RUN   TestAccZone_primary_to_secondary_to_normal
--- PASS: TestAccZone_primary_to_secondary_to_normal (6.78s)
=== RUN   TestAccZone_secondary_to_primary_to_normal
--- PASS: TestAccZone_secondary_to_primary_to_normal (3.07s)
=== RUN   TestAccZone_dnssec
--- PASS: TestAccZone_dnssec (6.49s)
=== RUN   TestAccZone_hostmaster
--- PASS: TestAccZone_hostmaster (2.85s)
=== RUN   TestAccZone_TSIG
    testing.go:701: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: DELETE https://api.nsone.net/v1/zones/terraform-test-olfi1uza0p8hwkp.io: 500 Internal server error
[...]
--- FAIL: TestAccZone_TSIG (2.05s)
=== RUN   TestAccZone_disable_autogenerate_ns_record
--- PASS: TestAccZone_disable_autogenerate_ns_record (2.32s)
=== RUN   TestAccZone_ManualDelete
--- PASS: TestAccZone_ManualDelete (5.27s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-ns1/ns1	35.407s

```