### PR TITLE
release 1.13.2-pre1 (prerelease)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.13.2-pre1 (prerelease) (December 6, 2022)
+BUG FIXES
+
+* Upgrade to ns1-go v2.7.1 to get fix for rate-limit divide-by-zero error.
+
 ## 1.13.1 (December 5, 2022)
 ENHANCEMENTS
 * HTTP debug logging now includes request/response times and response data

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/fatih/structs v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.4.1
 	github.com/stretchr/testify v1.4.0
-	gopkg.in/ns1/ns1-go.v2 v2.7.0
+	gopkg.in/ns1/ns1-go.v2 v2.7.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/ns1/ns1-go.v2 v2.7.0 h1:dnybfLhXKnuTSm8w+iAPVxV5xWCgSF72KiKAC47O5fQ=
 gopkg.in/ns1/ns1-go.v2 v2.7.0/go.mod h1:g664JF7DeMJ5jIKrqJCE98h/o1Gma+5j7YU1r/D6438=
+gopkg.in/ns1/ns1-go.v2 v2.7.1 h1:dS3Lo1/D+7AsAhbRrgUEbcx4dPJ6klNQuAncrLOXrDg=
+gopkg.in/ns1/ns1-go.v2 v2.7.1/go.mod h1:g664JF7DeMJ5jIKrqJCE98h/o1Gma+5j7YU1r/D6438=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	clientVersion     = "1.13.1"
+	clientVersion     = "1.13.2-pre1"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 )
 


### PR DESCRIPTION
Upgrade to ns1-go v2.7.1 to get fix for rate-limit divide-by-zero error.