### PR TITLE
INBOX-2241/Add retries to Terraform provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ BUG FIXES
 
 ## 1.13.1 (December 5, 2022)
 ENHANCEMENTS
+
 * HTTP debug logging now includes request/response times and response data
 
 BUG FIXES
+
 * Update instead of delete/recreate when changing link attribute of DNS record
 * Region names in DNS record metadata now sorted to avoid false differences
 * Permission flag change detection fixes [issue 237](https://github.com/ns1-terraform/terraform-provider-ns1/issues/237)
@@ -17,11 +19,13 @@ BUG FIXES
 
 ## 1.13.1-pre1 (prerelease) (November 10, 2022)
 BUG FIXES
+
 * Update instead of delete/recreate when changing link attribute of DNS record
 * Fix documentation typo
 
 ## 1.13.0 (November 8, 2022)
 ENHANCEMENTS:
+
 * Added importers for datafeed, datasource, notifylist and monitoringjob [#235](https://github.com/ns1-terraform/terraform-provider-ns1/pull/235)
 * Added support for additional secondary zone attributes [#233](https://github.com/ns1-terraform/terraform-provider-ns1/pull/233)
 * Added DNS view support [#234](https://github.com/ns1-terraform/terraform-provider-ns1/pull/234)
@@ -29,6 +33,7 @@ ENHANCEMENTS:
 * Requires ns1-go v2.7.0
 
 BUG FIXES
+
 * Mitigated a race condition that caused false errors to be returned when verifying a newly-created zone with DNSSEC enabled [#235](https://github.com/ns1-terraform/terraform-provider-ns1/pull/235/files#diff-6951d991dadec97cca66b3e918a78392de104f53e86ce520f478f0cca3653e2f)
 * Monitoring job rules can now be deleting by removing them from the resource file (empty rules cannot be explicitly specified due to Terraform limitations) [see ns1-go PR 173](https://github.com/ns1/ns1-go/pull/173/files)
 * Better handling of monitoring job region names [#229](https://github.com/ns1-terraform/terraform-provider-ns1/pull/229)
@@ -39,47 +44,57 @@ BUG FIXES
 ## 1.12.8 (September 12, 2022)
 
 BUG FIXES:
+
 * Sort monitoring job region names alphabetically to avoid unnecessary state pushes [#224](https://github.com/ns1-terraform/terraform-provider-ns1/pull/224)
 
 
 ## 1.12.7 (May 26, 2022)
 
 ENCHANCEMENTS:
+
 * Makes hostmaster field available for use [#213](https://github.com/ns1-terraform/terraform-provider-ns1/pull/213)
 * Adds support for CRUD operations on subnets [#210](https://github.com/ns1-terraform/terraform-provider-ns1/pull/210)
 
 ## 1.12.6 (April 11, 2022)
 ENHANCEMENTS:
+
 * Adds support to override TTL [#209](https://github.com/ns1-terraform/terraform-provider-ns1/pull/209)
 * Adds TSIG support [#188](https://github.com/ns1-terraform/terraform-provider-ns1/pull/188)
 * Mark API keys as sensitive fields [#192](https://github.com/ns1-terraform/terraform-provider-ns1/pull/192)
 
 BUG FIXES:
+
 * Fixes an issue with subdivision parsing [#207](https://github.com/ns1-terraform/terraform-provider-ns1/pull/207)
 * Fixes capitalization issue [#208](https://github.com/ns1-terraform/terraform-provider-ns1/pull/208)
 
 ## 1.12.5 (February 01, 2022)
 ENHANCEMENTS:
+
 * Updates go version to 1.17 to provide release binaries for darwin arm64
 
 ## 1.12.4 (January 27, 2022)
 ENHANCEMENTS:
+
 * Resolves subdivision formatting inconsistency with answers meta and regions meta
 
 ## 1.12.3 (January 24, 2022)
 ENHANCEMENTS:
+
 * Resolves subdivision formatting inconsistency
 
 ## 1.12.2 (January 07, 2022)
 ENHANCEMENTS:
+
 * Various documentation updates
 * Added support for team and user import [#193](https://github.com/ns1-terraform/terraform-provider-ns1/pull/193)
 
 ## 1.12.1 (September 23, 2021)
 ENHANCEMENTS:
+
 * Added additional validation for notify lists [#180](https://github.com/ns1-terraform/terraform-provider-ns1/pull/180)
 
 BUG FIXES:
+
 * Various documentation updates
 * Fixed an issue with changing the order of record filters [#177](https://github.com/ns1-terraform/terraform-provider-ns1/pull/177)
 * Fixed an issue with ordering in IP whitelists [#178](https://github.com/ns1-terraform/terraform-provider-ns1/pull/178)
@@ -88,113 +103,138 @@ BUG FIXES:
 
 ## 1.12.0 (September 7, 2021)
 ENHANCEMENTS:
+
 * Adds support for Pulsar applications [#172](https://github.com/ns1-terraform/terraform-provider-ns1/pull/172)
 * Adds support for Pulsar jobs [#173](https://github.com/ns1-terraform/terraform-provider-ns1/pull/173)
 * Adds support for `dns_records_deny` and `dns_records_allow` permission fields [#165](https://github.com/ns1-terraform/terraform-provider-ns1/pull/165)
 * Adds support for the `mute` field on monitoring jobs [#166](https://github.com/ns1-terraform/terraform-provider-ns1/pull/166)
 
 BUG FIXES:
+
 * Fixed an issue with the `tls_add_verify` field on monitoring jobs [#171](https://github.com/ns1-terraform/terraform-provider-ns1/pull/171)
 * Resolved an issue with default permissions [#170](https://github.com/ns1-terraform/terraform-provider-ns1/pull/170)
 
 ## 1.11.0 (June 29, 2021)
 ENHANCEMENTS:
+
 * Adds support for subdivisions to record resources [#164](https://github.com/ns1-terraform/terraform-provider-ns1/pull/164)
 * Adds support for `dns_records_allow` and `dns_records_deny` permissions [#165](https://github.com/ns1-terraform/terraform-provider-ns1/pull/165)
 * Adds support for `mute` attribute to monitoring job resorce [#166](https://github.com/ns1-terraform/terraform-provider-ns1/pull/166)
 
 BUG FIXES:
+
 * Make `config` for filter chain of `record` computed if not provided [#167](https://github.com/ns1-terraform/terraform-provider-ns1/pull/167)
 
 ## 1.10.3 (June 15, 2021)
 ENHANCEMENTS:
+
 * Add more verbose logging output for failed requests [#160](https://github.com/ns1-terraform/terraform-provider-ns1/pull/160)
 * Update to documentation to reflect proper usage for monitoring datafeeds [#154](https://github.com/ns1-terraform/terraform-provider-ns1/pull/154) 
 
 BUG FIXES:
+
 * Correctly coerce `test_id` config value for datafeed resource used with `thousandeyes` `datasource` [#163](https://github.com/ns1-terraform/terraform-provider-ns1/pull/163)
 * Change `notify_failback` field in `monitoringjob` resource default to `true` to match default in api [#161](https://github.com/ns1-terraform/terraform-provider-ns1/pull/161)
 
 ## 1.10.2 (May 21, 2021)
 ENHANCEMENTS:
+
 * Updates ns1-go dependency to add handling of rate limitting when API returns 4xx error [#159](https://github.com/ns1-terraform/terraform-provider-ns1/pull/159).
 
 ## 1.10.1 (April 27, 2021)
 BUG FIXES:
+
 * Resolves issue with missing value for Key attribute when creating an apikey joined to a team [#158](https://github.com/ns1-terraform/terraform-provider-ns1/pull/158).
 
 ## 1.10.0 (April 22, 2021)
 ENHANCEMENTS:
+
 * Adds DS record support [#157](https://github.com/ns1-terraform/terraform-provider-ns1/pull/157).
 
 ## 1.9.4 (March 23, 2021)
 NOTES:
+
 * Updates docs to clarify `key` is an Attribute and not an Argument [#150](https://github.com/ns1-terraform/terraform-provider-ns1/pull/150).
 
 ## 1.9.3 (March 4, 2021)
 BUG FIXES:
+
 * Adds missing `account_manage_ip_whitelist` permission [#148](https://github.com/ns1-terraform/terraform-provider-ns1/pull/148).
 
 ## 1.9.2 (February 26, 2021)
 BUG FIXES:
+
 * Values for `tls_skip_verify` are coerced correctly [#146](https://github.com/ns1-terraform/terraform-provider-ns1/pull/146). Thanks @zahiar!
 
 ## 1.9.1 (January 7, 2021)
 BUG FIXES:
+
 * Values for IPv6 monitoring job configs are coerced correctly [#141](https://github.com/ns1-terraform/terraform-provider-ns1/pull/141).
 
 ## 1.9.0 (September 8, 2020)
 FEATURES:
+
 * **New Data Source:** `ns1_record` [#137](https://github.com/ns1-terraform/terraform-provider-ns1/pull/137). Thanks to @zahiar!
 
 ## 1.8.6 (August 31, 2020)
 ENHANCEMENTS:
+
 * Add additional config field to monitoring job configuration
 
 ## 1.8.5 (August 13, 2020)
 BUG FIXES:
+
 * Resolves issue with config maps returning floats sometimes
 
 ## 1.8.4 (June 24, 2020)
 BUG FIXES:
+
 * Resolves an issue where changes involving feed pointers in record answer metadata were not detected ([124](https://github.com/terraform-providers/terraform-provider-ns1/pull/124))
 
 ## 1.8.3 (May 21, 2020)
 BUG FIXES:
+
 * Resolves issues on record filter and meta fields around boolean values not properly being converted to strings ([123](https://github.com/terraform-providers/terraform-provider-ns1/pull/123)).
 
 ## 1.8.2 (May 01, 2020)
 NOTES:
+
 * Clarify rate limit documentation ([121](https://github.com/terraform-providers/terraform-provider-ns1/pull/121))
 * Replace examples in README with blurb pointing to docs ([120](https://github.com/terraform-providers/terraform-provider-ns1/pull/120))
 
 ## 1.8.1 (April 09, 2020)
 ENHANCEMENTS
+
  * Change username validation regex to match validation used by NS1 API.([#119](https://github.com/terraform-providers/terraform-provider-ns1/pull/119))
 
 ## 1.8.0 (March 19, 2020)
 
 ENHANCEMENTS:
+
 * support for pulsar metadata in record answers ([#116](https://github.com/terraform-providers/terraform-provider-ns1/issues/116))
 
 ## 1.7.1 (February 25, 2020)
 
 BUG FIXES:
+
 * Bump ns1-go SDK version to v2.2.1 - resolves an issue with ASNs causing
   panics ([#113](https://github.com/terraform-providers/terraform-provider-ns1/pull/113)).
 * Fix for IP Prefix ordering - don't show a change when order differs ([#112](https://github.com/terraform-providers/terraform-provider-ns1/pull/112)).
 
 ENHANCEMENTS:
+
 * Validate username field in the provider, so issues with usernames are caught
   in the "plan" stage ([#115](https://github.com/terraform-providers/terraform-provider-ns1/pull/115)).
 
 ## 1.7.0 (January 28, 2020)
 
 NOTES:
+
 * The `short_answers` attribute on `ns1_record` has had a deprecation warning added to it and will be deprecated in a future release ([#102](https://github.com/terraform-providers/terraform-provider-ns1/pull/102)).
 * The project has been tagged as under "active development", in accordance with NS1 standards around public facing repositories ([#109](https://github.com/terraform-providers/terraform-provider-ns1/pull/109)).
 
 ENHANCEMENTS:
+
 * Support for DDI permissions on teams, users, and API keys has been added,
 and can be enabled via the new `enable_ddi` configuration option on the provider ([#105](https://github.com/terraform-providers/terraform-provider-ns1/pull/105)).
 * Added IP Whitelist support for teams, users, and AIP keys ([#105](https://github.com/terraform-providers/terraform-provider-ns1/pull/105)).
@@ -203,6 +243,7 @@ and can be enabled via the new `enable_ddi` configuration option on the provider
 ## 1.6.4 (January 06, 2020)
 
 IMPROVEMENTS:
+
 * Updated permissions behavior on user and API key resources to accurately show `terraform plan` differences when the user or key is part of a team and updated documentation accordingly ([#100](https://github.com/terraform-providers/terraform-provider-ns1/pull/100))
 * Switched to the Terraform standalone SDK ([#101](https://github.com/terraform-providers/terraform-provider-ns1/pull/101))
 * Update resource state management to properly handle disappearing resources ([#99](https://github.com/terraform-providers/terraform-provider-ns1/pull/99))
@@ -210,49 +251,58 @@ IMPROVEMENTS:
 ## 1.6.3 (December 16, 2019)
 
 IMPROVEMENTS:
+
 * Add validation to the zone and domain fields on a record to more clearly indicate invalid inputs containing leading or trailing dots ([#97](https://github.com/terraform-providers/terraform-provider-ns1/pull/97))
 
 ## 1.6.2 (December 05, 2019)
 
 ENHANCEMENTS:
+
 * Support URLFWD records ([#96](https://github.com/terraform-providers/terraform-provider-ns1/issues/96))
 * Add a "clean" rule to Makefile ([#89](https://github.com/terraform-providers/terraform-provider-ns1/issues/89))
 
 ## 1.6.1 (November 13, 2019)
 
 BUG FIXES:
+
 * fix interaction with the `autogenerate_ns_record` flag that was making terraform think a clean resource was dirty ([#85](https://github.com/terraform-providers/terraform-provider-ns1/issues/85))
 
 ENHANCEMENTS:
+
 * docs and example for using `autogenerate_ns_record`. ([#83](https://github.com/terraform-providers/terraform-provider-ns1/issues/83))
 * minor improvements to some error messages in tests.
 * improve docs around the ordering requirement for zone regions.
 * improve docs around provider arguments and environment variables.
 
 IMPROVEMENTS:
+
 * Add a configuration option to the provider to use an alternate strategy to avoid rate limit errors. ([#88](https://github.com/terraform-providers/terraform-provider-ns1/issues/88))
 
 ## 1.6.0 (October 16, 2019)
 
 BUG FIXES:
+
 * Pick up a divide by zero fix in the SDK, when rate limiting. Should wait around when hitting limits rather
   than falling over, and shouldn't require limiting parallelism to avoid 429 errors. ([#74](https://github.com/terraform-providers/terraform-provider-ns1/issues/74))
  * We were explicitly sending defaults for `port` and `notify` fields in `secondaries`, now they are implicit.
    Sending the default `port` prevented using IP ranges. ([#82](https://github.com/terraform-providers/terraform-provider-ns1/issues/82))
  
 ENHANCEMENTS:
+
 * Allow secondary zone -> primary zone in-place. Old behavior was to force a new resource (DELETE/PUT) on any
   change to secondary. Now the only one that requires a new resource is when a zone _becomes_ a secondary. See
   the note in docs. ([#75](https://github.com/terraform-providers/terraform-provider-ns1/issues/75))
 * Support for CAA records. ([#78](https://github.com/terraform-providers/terraform-provider-ns1/issues/78))
   
 DEPRECATION:
+
 * We've bumped the CI tests to run under Go 1.12. Provider still works with 1.11, but we're developing on and
   targeting 1.12+ ([#76](https://github.com/terraform-providers/terraform-provider-ns1/issues/76))
 
 ## 1.5.3 (October 02, 2019)
 
 BUG FIXES:
+
 * Disallow setting SOA fields (refresh, retry, expiry, and nx_ttl) on secondary zones. An API bug allowed
   these fields to be set on "create", the API now discards any settings to these fields and sets them to default
   values. These fields are now marked as "ConflictsWith" for secondary zones. If you were doing this and tf complains

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/hashicorp/go-hclog v0.9.2 // indirect
 	github.com/hashicorp/go-multierror v1.0.0 // indirect
 	github.com/hashicorp/go-plugin v1.0.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/go-version v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v1.0.1 h1:4OtAfUGbnKC6yS48p0CtMX2oFYtzFZVv6rok3cRWgnE=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
@@ -298,8 +300,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
-gopkg.in/ns1/ns1-go.v2 v2.7.0 h1:dnybfLhXKnuTSm8w+iAPVxV5xWCgSF72KiKAC47O5fQ=
-gopkg.in/ns1/ns1-go.v2 v2.7.0/go.mod h1:g664JF7DeMJ5jIKrqJCE98h/o1Gma+5j7YU1r/D6438=
 gopkg.in/ns1/ns1-go.v2 v2.7.1 h1:dS3Lo1/D+7AsAhbRrgUEbcx4dPJ6klNQuAncrLOXrDg=
 gopkg.in/ns1/ns1-go.v2 v2.7.1/go.mod h1:g664JF7DeMJ5jIKrqJCE98h/o1Gma+5j7YU1r/D6438=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
 )
 
@@ -34,7 +35,10 @@ type Config struct {
 // Client returns a new NS1 client.
 func (c *Config) Client() (*ns1.Client, error) {
 	var client *ns1.Client
-	httpClient := &http.Client{}
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 4
+	retryClient.Logger = nil
+	httpClient := retryClient.StandardClient()
 	decos := []func(*ns1.Client){}
 
 	if c.Key == "" {

--- a/ns1/provider.go
+++ b/ns1/provider.go
@@ -115,8 +115,8 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"api_key": "The ns1 API key (required)",
-		"endpoint": "URL prefix (including version) for API calls",
+		"api_key":   "The ns1 API key (required)",
+		"endpoint":  "URL prefix (including version) for API calls",
 		"retry_max": "Maximum retries for 50x errors (-1 to disable)",
 	}
 

--- a/ns1/provider.go
+++ b/ns1/provider.go
@@ -43,6 +43,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("NS1_RATE_LIMIT_PARALLELISM", nil),
 				Description: descriptions["rate_limit_parallelism"],
 			},
+			"retry_max": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NS1_RETRY_MAX", nil),
+				Description: descriptions["retry_max"],
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ns1_zone":   dataSourceZone(),
@@ -98,6 +104,9 @@ func ns1Configure(d *schema.ResourceData) (interface{}, error) {
 	if v, ok := d.GetOk("rate_limit_parallelism"); ok {
 		config.RateLimitParallelism = v.(int)
 	}
+	if v, ok := d.GetOk("retry_max"); ok {
+		config.RetryMax = v.(int)
+	}
 
 	return config.Client()
 }
@@ -106,7 +115,9 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"api_key": "The ns1 API key, this is required",
+		"api_key": "The ns1 API key (required)",
+		"endpoint": "URL prefix (including version) for API calls",
+		"retry_max": "Maximum retries for 50x errors (-1 to disable)",
 	}
 
 	structs.DefaultTagName = "json"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -35,10 +35,9 @@ The following arguments are supported:
 
 * `apikey` - (Required) NS1 API token. It must be provided, but it can also
   be sourced from the `NS1_APIKEY` environment variable.
-* `version` - (Optional, but recommended if you don't like surprises) From
-  output of `terraform init`.
-* `endpoint` - (Optional) NS1 API endpoint. For managed clients, this normally
-  should not be set.
+* `version` - (Optional, but recommended if you don't like surprises) Require a specific version of the NS1 provider. Run `terraform init` to get your current version.
+* `retry_max` - (Optional, introduced in v1.13.2) Sets the number of retries for 50x-series errors. The default is 3. A negative value such as -1 disables this feature.
+* `endpoint` - (Optional) NS1 API endpoint. Normally not set unless testing or using non-standard proxies.
 * `ignore_ssl` - (Optional) This normally does not need to be set.
 * `enable_ddi` - (Optional) This sets the permission schema to a DDI-compatible schema. 
 Users of the managed SaaS product should not need to set this.
@@ -71,6 +70,7 @@ embedding in the config:
 
 * `NS1_APIKEY` - (string) Explained above.
 * `NS1_ENDPOINT` - (string) Explained above.
+* `NS1_RETRY_MAX` - (integer) Explained above.
 * `NS1_IGNORE_SSL` - (boolean) If set, follows the convention of
   [strconv.ParseBool](https://golang.org/pkg/strconv/#ParseBool).
 * `NS1_RATE_LIMIT_PARALLELISM` - (int) Explained above.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -39,9 +39,7 @@ The following arguments are supported:
 * `retry_max` - (Optional, introduced in v1.13.2) Sets the number of retries for 50x-series errors. The default is 3. A negative value such as -1 disables this feature.
 * `endpoint` - (Optional) NS1 API endpoint. Normally not set unless testing or using non-standard proxies.
 * `ignore_ssl` - (Optional) This normally does not need to be set.
-* `enable_ddi` - (Optional) This sets the permission schema to a DDI-compatible schema. 
-Users of the managed SaaS product should not need to set this.
-Users of DDI should set this to true if managing teams, users, or API keys through this provider.
+* `enable_ddi` - (Deprecated) Enable the DDI-compatible permissions schema. No longer in use.
 * `rate_limit_parallelism` - (Optional) Integer for alternative rate limit and parallelism strategy (Terraform default value is 10).
     NS1 uses a token-based method for rate limiting API requests. Details of which can be found here: https://help.ns1.com/hc/en-us/articles/360020250573-About-API-rate-limiting.
     


### PR DESCRIPTION
* use the Hashicorp retryable-http library by default
* add new configuration parameter `retry_max` to tune or disable the retries
* documentation updates