### PR TITLE
release 1.13.2-pre3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.13.2-pre3 (prerelease) (December 14, 2022)
+BUG FIXES
+
+* Fixed CAA record answers to allow answers with spaces after a domain  [issue 238](https://github.com/ns1-terraform/terraform-provider-ns1/issues/238)
+* Upgrade to ns1-go v2.7.2 to get messages from HTTP 50x errors properly displayed.
+* Upgraded to Terraform SDK 1.17.2
+* Misc documentation fixes.
+
 ## 1.13.2-pre2 (prerelease) (December 8, 2022)
 ENHANCEMENTS
 

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "1.13.2-pre2"
+	clientVersion     = "1.13.2-pre3"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )


### PR DESCRIPTION
## 1.13.2-pre3 (prerelease) (December 14, 2022)
BUG FIXES

* Fixed CAA record answers to allow answers with spaces after a domain  ([issue 238](https://github.com/ns1-terraform/terraform-provider-ns1/issues/238))
* Upgrade to ns1-go v2.7.2 to get messages from HTTP 50x errors properly displayed.
* Upgraded to Terraform SDK 1.17.2
* Misc documentation fixes.
