### PR TITLE
release 1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.13.2 (December 21, 2022)
+## 1.13.3 (December 21, 2022)
 ENHANCEMENTS
 
 * The [Hashicorp go-retryablehttp](https://github.com/hashicorp/go-retryablehttp) package is now used by default to retry requests when encountering 502/503 errors or connection errors.

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "1.13.2"
+	clientVersion     = "1.13.3"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )


### PR DESCRIPTION
## 1.13.3 (December 21, 2022)
ENHANCEMENTS

* The [Hashicorp go-retryablehttp](https://github.com/hashicorp/go-retryablehttp) package is now used by default to retry requests when encountering 502/503 errors or connection errors.
* Upgraded to Terraform SDK 1.17.2
* Upgraded to ns1-go 2.7.2

BUG FIXES

* Fix recognition of datafeed "not found" errors.
* Fixed CAA record answers to allow answers with spaces after a domain  ([issue 238](https://github.com/ns1-terraform/terraform-provider-ns1/issues/238))
* HTTP 50x and similar errors are now properly displayed.
* API keys can now be imported.
* Documentation corrections and updates.
* Fixed rate-limit divide-by-zero error.