### PR TITLE
release 1.13.4-pre1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.13.4-pre1 (December 22, 2022)
+BUG FIXES
+
+* fixed permissions problems with DNS record allow/deny lists (issues 196 and 197)
+
 ## 1.13.3 (December 21, 2022)
 ENHANCEMENTS
 

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "1.13.3"
+	clientVersion     = "1.13.4-pre1"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )


### PR DESCRIPTION
## 1.13.4-pre1 (December 22, 2022)
BUG FIXES

* fixed permissions problems with DNS record allow/deny lists (issues #196 and #197)