### PR TITLE
INBOX-2198/fix issues discovered by sdk2 testing

### DIFF
--- a/ns1/config.go
+++ b/ns1/config.go
@@ -118,7 +118,10 @@ func Logging() ns1.Decorator {
 			requestTime := time.Now()
 			response, rerr := d.Do(r)
 			responseTime := time.Now()
-			dump, _ := httputil.DumpResponse(response, true)
+			dump := []byte{}
+			if response != nil {
+				dump, _ = httputil.DumpResponse(response, true)
+			}
 			for _, m := range msgs {
 				log.Print(m)
 			}

--- a/ns1/data_source_record.go
+++ b/ns1/data_source_record.go
@@ -23,6 +23,10 @@ func dataSourceRecord() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"override_ttl": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"meta": {
 				Type:     schema.TypeMap,
 				Computed: true,

--- a/ns1/data_source_zone.go
+++ b/ns1/data_source_zone.go
@@ -46,6 +46,17 @@ func dataSourceZone() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"additional_ports": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+			"primary_port": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+			},
 			"dns_servers": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/ns1/data_source_zone.go
+++ b/ns1/data_source_zone.go
@@ -54,8 +54,8 @@ func dataSourceZone() *schema.Resource {
 				},
 			},
 			"primary_port": {
-				Type:          schema.TypeInt,
-				Optional:      true,
+				Type:     schema.TypeInt,
+				Optional: true,
 			},
 			"dns_servers": {
 				Type:     schema.TypeString,

--- a/ns1/resource_apikey.go
+++ b/ns1/resource_apikey.go
@@ -131,7 +131,7 @@ func ApikeyRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ns1.Client)
 	k, resp, err := client.APIKeys.Get(d.Id())
 	if err != nil {
-		if err == ns1.ErrKeyMissing {
+		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("[DEBUG] NS1 API key (%s) not found", d.Id())
 			d.SetId("")
 			return nil

--- a/ns1/resource_apikey_test.go
+++ b/ns1/resource_apikey_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"regexp"
 	"sort"
 	"testing"
 
@@ -97,7 +96,6 @@ func TestAccAPIKey_ManualDelete(t *testing.T) {
 				PreConfig:          testAccManualDeleteAPIKey(&apiKey),
 				Config:             testAccAPIKeyBasic(name),
 				PlanOnly:           true,
-				ExpectError:        regexp.MustCompile("GET .*/account/apikeys/.* not found"),
 				ExpectNonEmptyPlan: true,
 			},
 			// Then re-create and make sure it is there again.

--- a/ns1/resource_datafeed.go
+++ b/ns1/resource_datafeed.go
@@ -46,14 +46,22 @@ func dataFeedToResourceData(d *schema.ResourceData, f *data.Feed) {
 }
 
 func resourceDataToDataFeed(d *schema.ResourceData) (feed *data.Feed, e error) {
-	err := configAdapterIn(d)
-	if err != nil {
-		return nil, err
+	config := d.Get("config").(map[string]interface{})
+	if config != nil {
+		test_id := config["test_id"]
+		if test_id != nil {
+			test_id_int, err := strconv.Atoi(test_id.(string))
+			if err != nil {
+				return &data.Feed{}, fmt.Errorf("could not convert %v as int %w", test_id, err)
+			}
+			config["test_id"] = test_id_int
+		}
 	}
+
 	return &data.Feed{
 		Name:     d.Get("name").(string),
 		SourceID: d.Get("source_id").(string),
-		Config:   d.Get("config").(map[string]interface{}),
+		Config:   config,
 	}, nil
 }
 
@@ -109,23 +117,6 @@ func DataFeedUpdate(d *schema.ResourceData, meta interface{}) error {
 		return ConvertToNs1Error(resp, err)
 	}
 	dataFeedToResourceData(d, f)
-	return nil
-}
-
-// configAdapterIn adapts the configuration types
-func configAdapterIn(d *schema.ResourceData) error {
-	config := d.Get("config").(map[string]interface{})
-	if config != nil {
-		test_id := config["test_id"]
-		if test_id != nil {
-			test_id_int, err := strconv.Atoi(test_id.(string))
-			if err != nil {
-				return fmt.Errorf("could not convert %v as int %w", test_id, err)
-			}
-			config["test_id"] = test_id_int
-			d.Set("config", config)
-		}
-	}
 	return nil
 }
 

--- a/ns1/resource_monitoringjob.go
+++ b/ns1/resource_monitoringjob.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
@@ -281,8 +280,7 @@ func MonitoringJobRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ns1.Client)
 	j, resp, err := client.Jobs.Get(d.Id())
 	if err != nil {
-		// No custom error type is currently defined in the SDK for a monitoring job.
-		if strings.Contains(err.Error(), "unknown monitoring job") {
+		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("[DEBUG] NS1 record (%s) not found", d.Id())
 			d.SetId("")
 			return nil

--- a/ns1/resource_monitoringjob_test.go
+++ b/ns1/resource_monitoringjob_test.go
@@ -3,7 +3,6 @@ package ns1
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -138,7 +137,6 @@ func TestAccMonitoringJob_ManualDelete(t *testing.T) {
 				Config:             testAccMonitoringJobBasic,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile("GET .*/monitoring/jobs/.* was not found"),
 			},
 			// Then re-create and make sure it is there again.
 			{

--- a/ns1/resource_notifylist.go
+++ b/ns1/resource_notifylist.go
@@ -141,7 +141,7 @@ func NotifyListRead(d *schema.ResourceData, meta interface{}) error {
 
 	nl, resp, err := client.Notifications.Get(d.Id())
 	if err != nil {
-		if err == ns1.ErrListMissing {
+		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("[DEBUG] NS1 notify list (%s) not found", d.Id())
 			d.SetId("")
 			return nil

--- a/ns1/resource_notifylist_test.go
+++ b/ns1/resource_notifylist_test.go
@@ -3,7 +3,6 @@ package ns1
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -103,7 +102,6 @@ func TestAccNotifyList_types(t *testing.T) {
 
 func TestAccNotifyList_ManualDelete(t *testing.T) {
 	var nl monitor.NotifyList
-	notFoundExp, _ := regexp.Compile("GET http.*/v1/lists/.* 404 ?")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -120,7 +118,6 @@ func TestAccNotifyList_ManualDelete(t *testing.T) {
 				Config:             testAccNotifyListBasic,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        notFoundExp,
 			},
 			// Then re-create and make sure it is there again.
 			{

--- a/ns1/resource_record_test.go
+++ b/ns1/resource_record_test.go
@@ -224,7 +224,7 @@ func TestAccRecord_CAA(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "ns1_record.it",
+				ResourceName:      "ns1_record.caa",
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("%[1]s/%[1]s/CAA", zoneName),
 				ImportStateVerify: true,
@@ -266,7 +266,7 @@ func TestAccRecord_SPF(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "ns1_record.it",
+				ResourceName:      "ns1_record.spf",
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("%[1]s/%[1]s/SPF", zoneName),
 				ImportStateVerify: true,
@@ -302,7 +302,7 @@ func TestAccRecord_SRV(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "ns1_record.it",
+				ResourceName:      "ns1_record.srv",
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("%s/%s/SRV", zoneName, domainName),
 				ImportStateVerify: true,
@@ -338,7 +338,7 @@ func TestAccRecord_DS(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "ns1_record.it",
+				ResourceName:      "ns1_record.ds",
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("%s/%s/DS", zoneName, domainName),
 				ImportStateVerify: true,
@@ -373,7 +373,7 @@ func TestAccRecord_URLFWD(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "ns1_record.it",
+				ResourceName:      "ns1_record.urlfwd",
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("%s/%s/URLFWD", zoneName, domainName),
 				ImportStateVerify: true,

--- a/ns1/resource_team.go
+++ b/ns1/resource_team.go
@@ -121,7 +121,7 @@ func TeamRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ns1.Client)
 	t, resp, err := client.Teams.Get(d.Id())
 	if err != nil {
-		if err == ns1.ErrTeamMissing {
+		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("[DEBUG] NS1 team (%s) not found", d.Id())
 			d.SetId("")
 			return nil

--- a/ns1/resource_team_test.go
+++ b/ns1/resource_team_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"regexp"
 	"sort"
 	"testing"
 
@@ -103,7 +102,6 @@ func TestAccTeam_ManualDelete(t *testing.T) {
 				Config:             testAccTeamBasic,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile("GET .*/account/teams/.* not found"),
 			},
 			// Then re-create and make sure it is there again.
 			{

--- a/ns1/resource_user.go
+++ b/ns1/resource_user.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
@@ -152,8 +151,7 @@ func UserRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ns1.Client)
 	u, resp, err := client.Users.Get(d.Id())
 	if err != nil {
-		// No custom error type is currently defined in the SDK for a non-existent user.
-		if strings.Contains(err.Error(), "User not found") {
+		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("[DEBUG] NS1 user (%s) not found", d.Id())
 			d.SetId("")
 			return nil

--- a/ns1/resource_user_test.go
+++ b/ns1/resource_user_test.go
@@ -79,13 +79,14 @@ func TestAccUser_ManualDelete(t *testing.T) {
 				PreConfig:          testAccManualDeleteUser(username),
 				Config:             testAccUserBasic(rString),
 				PlanOnly:           true,
-				ExpectError:        regexp.MustCompile("GET .*/account/users/.* not found"),
 				ExpectNonEmptyPlan: true,
 			},
 			// Attempt to re-create it, this should fail because user names must be historically unique.
+			// Error: PUT https://api.nsone.net/v1/account/users: 409 login name tf_acc_test_user_k8qsnpxghuhgmip already exists
+
 			{
 				Config:      testAccUserBasic(rString),
-				ExpectError: regexp.MustCompile(`PUT .*/account/teams.*already exists`),
+				ExpectError: regexp.MustCompile(`PUT .*/account/users.*already exists`),
 			},
 		},
 	})


### PR DESCRIPTION
* add missing fields to datasource schemas
* use temporary variables for type conversion instead of trying to change the value in a schema
* fix tests that weren't testing the right record name
* fix HTTP debug mode to prevent panic when retry failure occurs
* detect missing resources by using 404 status instead of unreliable scraping of API text responses