### PR TITLE
release 1.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.13.4 (January 10, 2023)
+ENHANCEMENTS
+
+* User-agent string can now be customized in the resource file.
+* Upgraded to ns1-go 2.7.3
+
+BUG FIXES
+
+* Fixed permissions problems with DNS record allow/deny lists (issues 196 and 197)
+* Fixed a few cases where objects deleted from infrastructure but still in state were not being recognized correctly.
+* Fixed error in HTTP response debug logging
+* Datasource and datafeed schema fixes
+
 ## 1.13.4-pre1 (December 22, 2022)
 BUG FIXES
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ NS1 Terraform Provider
 
 - NS1 Website: https://www.ns1.com
 - Terraform Website: https://www.terraform.io
+- Terraform NS1 Provider Documentation: https://registry.terraform.io/providers/ns1-terraform/ns1/latest/docs
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "1.13.4-pre1"
+	clientVersion     = "1.13.4"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -49,6 +49,7 @@ The following arguments are supported:
 * `endpoint` - (Optional) NS1 API endpoint. Normally not set unless testing or using non-standard proxies.
 * `ignore_ssl` - (Optional) This normally does not need to be set.
 * `enable_ddi` - (Deprecated) Enable the DDI-compatible permissions schema. No longer in use.
+* `user_agent` - (Optional, introduced in v1.13.4) Sets the User-Agent header in the NS1 API.
 * `rate_limit_parallelism` - (Optional) Integer for alternative rate limit and parallelism strategy.
     NS1 uses a token-based method for rate limiting API requests. Full details can be found at https://help.ns1.com/hc/en-us/articles/360020250573-About-API-rate-limiting.
     


### PR DESCRIPTION
## 1.13.4 (January 10, 2023)
ENHANCEMENTS

* User-agent string can now be customized in the resource file.
* Upgraded to ns1-go 2.7.3

BUG FIXES

* Fixed permissions problems with DNS record allow/deny lists (issues 196 and 197)
* Fixed a few cases where objects deleted from infrastructure but still in state were not being recognized correctly.
* Fixed error in HTTP response debug logging
* Datasource and datafeed schema fixes
