### PR TITLE
release 2.0.0-pre1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-pre1 (release pending)
+## 2.0.0-pre1 (January 18, 2023)
 ENHANCEMENTS
 
 * Upgraded to Terraform SDK 2.24.1. Users of Pulsar will need to make minor changes in their resource files, see below.
@@ -22,7 +22,7 @@ resource "ns1_application" "it" {
 }
 ```
 
-instead of:
+instead of the previous syntax:
 ```
  default_config = {
 ```

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.0.0-pre1" // placeholder version until we release
+	clientVersion     = "2.0.0-pre1"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )


### PR DESCRIPTION
## 2.0.0-pre1 (January 18, 2023)
ENHANCEMENTS

* Upgraded to Terraform SDK 2.24.1. Users of Pulsar will need to make minor changes in their resource files, see below.

INCOMPATIBILITIES WITH PREVIOUS VERSIONS

* The `ns1_application` resource attributes `config`, `default_config` and `blended_metric_weights` are now blocks, with only one item permitted. This is due to an SDK 2.x restriction on nested structures. Existing resource files will need to be edited to remove the equals sign in the declarations of the affected stanzas.