### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.0.1 (March 14, 2023)
+BUG FIX
+
+* `ns1-go` client version bump fixes `additional_metadata` not applying correctly
+
+Note:
+* To avoid whitespace issues in `additional_metadata` meta tag using `jsonencode` for example:
+
+``` hcl
+meta = {
+  "additional_metadata" : jsonencode(
+    [
+      {
+        a = "1"
+        b = "3"
+      }
+  ])
+}
+```
+
 ## 2.0.0 (March 2, 2023)
 ENHANCEMENTS
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/stretchr/testify v1.8.1
-	gopkg.in/ns1/ns1-go.v2 v2.7.4
+	gopkg.in/ns1/ns1-go.v2 v2.7.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/ns1/ns1-go.v2 v2.7.4 h1:uLb8u8uM9E7Xij/GHPctVIKMwyQDcA8NjSPnScG7gmQ=
-gopkg.in/ns1/ns1-go.v2 v2.7.4/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
+gopkg.in/ns1/ns1-go.v2 v2.7.5 h1:tE4SLOAFx2YXawh6MPv57lmlaBFUTyxSYOWKOGDgkM4=
+gopkg.in/ns1/ns1-go.v2 v2.7.5/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.0.0"
+	clientVersion     = "2.0.1"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )


### PR DESCRIPTION
BUG FIX

* `ns1-go` client version bump fixes `additional_metadata` not applying correctly

Note:
* To avoid whitespace issues in `additional_metadata` meta tag using `jsonencode` for example:

``` hcl
meta = {
  "additional_metadata" : jsonencode(
    [
      {
        a = "1"
        b = "3"
      }
  ])
}