### PR TITLE
Bump ns1-go to 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 2.2.1 (April 3, 2024)
+BUGFIX
+* `ns1-go` client version bump to fix omitting tags
+
 ## 2.2.0 (March 7, 2024)
 ENHANCEMENTS
 * Adds support for listing available monitoring regions
-  
+
 ## 2.1.0 (February 14, 2024)
 ENHANCEMENTS
 * Adds support for Datasets
@@ -88,7 +92,7 @@ instead of the previous syntax:
  default_config = {
 ```
 
-* Added `networks` resource it provides details about NS1 Networks. Use this if you would simply like to read information from NS1 into your configurations, for example: 
+* Added `networks` resource it provides details about NS1 Networks. Use this if you would simply like to read information from NS1 into your configurations, for example:
 
 ```hcl
 # Get details about NS1 Networks.
@@ -303,7 +307,7 @@ BUG FIXES:
 ENHANCEMENTS:
 
 * Add more verbose logging output for failed requests [#160](https://github.com/ns1-terraform/terraform-provider-ns1/pull/160)
-* Update to documentation to reflect proper usage for monitoring datafeeds [#154](https://github.com/ns1-terraform/terraform-provider-ns1/pull/154) 
+* Update to documentation to reflect proper usage for monitoring datafeeds [#154](https://github.com/ns1-terraform/terraform-provider-ns1/pull/154)
 
 BUG FIXES:
 
@@ -460,14 +464,14 @@ BUG FIXES:
   than falling over, and shouldn't require limiting parallelism to avoid 429 errors. ([#74](https://github.com/terraform-providers/terraform-provider-ns1/issues/74))
  * We were explicitly sending defaults for `port` and `notify` fields in `secondaries`, now they are implicit.
    Sending the default `port` prevented using IP ranges. ([#82](https://github.com/terraform-providers/terraform-provider-ns1/issues/82))
- 
+
 ENHANCEMENTS:
 
 * Allow secondary zone -> primary zone in-place. Old behavior was to force a new resource (DELETE/PUT) on any
   change to secondary. Now the only one that requires a new resource is when a zone _becomes_ a secondary. See
   the note in docs. ([#75](https://github.com/terraform-providers/terraform-provider-ns1/issues/75))
 * Support for CAA records. ([#78](https://github.com/terraform-providers/terraform-provider-ns1/issues/78))
-  
+
 DEPRECATION:
 
 * We've bumped the CI tests to run under Go 1.12. Provider still works with 1.11, but we're developing on and
@@ -498,7 +502,7 @@ ENHANCEMENTS:
 IMPROVEMENTS:
 
 * acc tests: Randomize zone names to help prevent collisions ([#64](https://github.com/terraform-providers/terraform-provider-ns1/issues/64))
-* Ignore order of location fields (comma sep strings) in record regions block [[#68](https://github.com/terraform-providers/terraform-provider-ns1/issues/68)] 
+* Ignore order of location fields (comma sep strings) in record regions block [[#68](https://github.com/terraform-providers/terraform-provider-ns1/issues/68)]
 * Correct and improve docs around "regions" in record resource ([#69](https://github.com/terraform-providers/terraform-provider-ns1/issues/69))
 
 ## 1.5.1 (August 30, 2019)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/stretchr/testify v1.8.1
-	gopkg.in/ns1/ns1-go.v2 v2.9.0
+	gopkg.in/ns1/ns1-go.v2 v2.9.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/ns1/ns1-go.v2 v2.9.0 h1:6sEUgb0bSNM4AqgUe44iIcHhwAAr1MakiqC7Ul5j8IM=
-gopkg.in/ns1/ns1-go.v2 v2.9.0/go.mod h1:pfaU0vECVP7DIOr453z03HXS6dFJpXdNRwOyRzwmPSc=
+gopkg.in/ns1/ns1-go.v2 v2.9.1 h1:3/QYzUazRCSE49d3sh1Q+X7IrDp/I7OqR/M7dKA0Oks=
+gopkg.in/ns1/ns1-go.v2 v2.9.1/go.mod h1:pfaU0vECVP7DIOr453z03HXS6dFJpXdNRwOyRzwmPSc=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.2.0"
+	clientVersion     = "2.2.1"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )


### PR DESCRIPTION
`ns1-go` client version bump to fix omitting tags