### PR TITLE
Fix regions update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1 (June 28, 2024)
+BUGFIX
+* Fix issue with updating regions in record resource
+
 ## 2.3.0 (June 18, 2024)
 ENHANCEMENTS
 * Adds support for redirect endpoints

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.3.0"
+	clientVersion     = "2.3.1"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )


### PR DESCRIPTION
DESCRIPTION: receiving 400 errors when trying to update or modify regions (answer groups) with the new version of the Terraform provider.  Adding answer groups to a record currently works

The main issue is that TF can add empty elements in sets, so fixing that by ignoring elements where the name is empty.

Also the need to update tags and blocked_tags at the same time has been overcome, so removing that check.

Right now TestAccRecord_meta and TestAccRecord_meta_with_json are failing for me (on a PUT /v1/monitoring/jobs), but I get the same result with the master branch so it seems unrelated.