### PR TITLE
Allow IDN TLDs in redirect domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.2 (September 16, 2024)
+* Modified domain regex for redirects to allow internationalised domains
+
 ## 2.4.1 (August 23, 2024)
 * Fixed validation regex for redirects
 

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.4.1"
+	clientVersion     = "2.4.2"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )

--- a/ns1/resource_redirect.go
+++ b/ns1/resource_redirect.go
@@ -338,7 +338,7 @@ func RedirectCertUpdate(d *schema.ResourceData, meta interface{}) error {
 func validateDomain(val interface{}, key string) (warns []string, errs []error) {
 	v := val.(string)
 
-	match, err := regexp.MatchString("^(\\*\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z0-9]+$", v)
+	match, err := regexp.MatchString("^(\\*\\.)?([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]$", v)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("%s is invalid, got: %s, error: %e", key, v, err))
 	}


### PR DESCRIPTION
The NS1 server is going to support IDN TLDs soon, so that should be allowed in TF as well: we currently don't accept hyphens in the TLD.