### PR TITLE
Expand allowed redirect targets character set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.3 (October 2, 2024)
+* Modified target regex for redirects to align with server
+
 ## 2.4.2 (September 16, 2024)
 * Modified domain regex for redirects to allow internationalised domains
 

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.4.2"
+	clientVersion     = "2.4.3"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )

--- a/ns1/resource_redirect.go
+++ b/ns1/resource_redirect.go
@@ -370,7 +370,7 @@ func validatePath(val interface{}, key string) (warns []string, errs []error) {
 func validateURL(val interface{}, key string) (warns []string, errs []error) {
 	v := val.(string)
 
-	match, err := regexp.MatchString("^(http://|https://)?[a-zA-Z0-9\\-\\.]+(:\\d+)?(/[a-zA-Z0-9\\.\\-/_~%%:]*)?(\\?[a-zA-Z0-9\\.\\-/_~%%=+&#]+)?(#[a-zA-Z0-9\\.\\-/_~%%]+)?$", v)
+	match, err := regexp.MatchString("^(http://|https://)?[a-zA-Z0-9\\-\\.]+(:\\d+)?(/[a-zA-Z0-9\\.\\-/_~%%:$&()*+,;=@!]*)?(\\?[a-zA-Z0-9\\.\\-/_~%%:$&()*+,;=@!]*)?(#[a-zA-Z0-9\\.\\-/_~%%:$&()*+,;=@!?]+)?$", v)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("%s is invalid, got: %s, error: %e", key, v, err))
 	}


### PR DESCRIPTION
The redirects APIs currently accept more characters in the target schema than Terraform does.