### PR TITLE
#323: Fix ordering issue on regions meta fields by hashing set on name only

### DIFF
--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -315,18 +315,14 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 		}
 	}
 	if len(r.Regions) > 0 {
-		regions := make([]map[string]interface{}, 0, len(r.Regions))
+		regions := schema.NewSet(regionHash, nil)
 		for name, region := range r.Regions {
 			newRegion := make(map[string]interface{})
 			newRegion["name"] = name
 			newRegion["meta"] = region.Meta.StringMap()
-			regions = append(regions, newRegion)
+			regions.Add(newRegion)
 		}
 		log.Printf("Setting regions %+v", regions)
-		err := d.Set("regions", regions)
-		if err != nil {
-			return fmt.Errorf("[DEBUG] Error setting regions for: %s, error: %#v", r.Domain, err)
-		}
 	}
 	return nil
 }
@@ -800,4 +796,15 @@ func subdivisionConverter(s string) (map[string]interface{}, error) {
 	}
 
 	return subdivisionsMap, nil
+}
+
+// regions are maps, but the names should be unique, so use the name as index
+func regionHash(i interface{}) int {
+	if m, ok := i.(map[string]interface{}); ok {
+		if n, ok := m["name"].(string); ok {
+			return schema.HashString(n)
+		}
+	}
+	// if the name is missing
+	return 0
 }

--- a/ns1/resource_record_test.go
+++ b/ns1/resource_record_test.go
@@ -1909,8 +1909,6 @@ resource "ns1_record" "it" {
   regions {
     name = "cal"
     meta = {
-			// country   = "CA,MX,RU,US"
-			// georegion = "AFRICA,EUROPE,US-CENTRAL,US-EAST,US-WEST"
 			country   = "RU,CA,MX,US"
 			georegion = "EUROPE,US-CENTRAL,US-WEST,AFRICA,US-EAST"
       weight    = 100

--- a/ns1/resource_record_test.go
+++ b/ns1/resource_record_test.go
@@ -540,6 +540,12 @@ func TestAccRecord_updatedWithRegions(t *testing.T) {
 				),
 			},
 			{
+				// Plan again to detect "loop" conditions
+				Config:             testAccRecordUpdatedWithRegionWeight(rString),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
 				Config: testAccRecordUpdatedWithRegions(rString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRecordExists("ns1_record.it", &record),
@@ -1903,7 +1909,11 @@ resource "ns1_record" "it" {
   regions {
     name = "cal"
     meta = {
-      weight = 100
+			// country   = "CA,MX,RU,US"
+			// georegion = "AFRICA,EUROPE,US-CENTRAL,US-EAST,US-WEST"
+			country   = "RU,CA,MX,US"
+			georegion = "EUROPE,US-CENTRAL,US-WEST,AFRICA,US-EAST"
+      weight    = 100
     }
   }
 


### PR DESCRIPTION
/fix #323

Since we changed the regions from list to set we're running into an ordering issue with the meta fields, because arrays of different orders have different hashes, so they will be different elements in the set regardless of the suppress calculation.
This change assumes that the name uniquely identifies a region, which should hold true.