### PR TITLE
Allow underscore in redirects but not certificates (HTTP only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.1 (February 5, 2025)
+ENHANCEMENTS
+* Allow underscore for non-HTTPS redirects
+
 ## 2.5.0 (December 13, 2024)
 ENHANCEMENTS
 * Adds support for alert endpoints

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.5.0"
+	clientVersion     = "2.5.1"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )

--- a/ns1/resource_redirect.go
+++ b/ns1/resource_redirect.go
@@ -338,7 +338,7 @@ func RedirectCertUpdate(d *schema.ResourceData, meta interface{}) error {
 func validateDomain(val interface{}, key string) (warns []string, errs []error) {
 	v := val.(string)
 
-	match, err := regexp.MatchString("^(\\*\\.)?([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]$", v)
+	match, err := regexp.MatchString("^(\\*\\.)?([a-zA-Z0-9-_]{1,63}\\.)+[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]$", v)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("%s is invalid, got: %s, error: %e", key, v, err))
 	}


### PR DESCRIPTION
Because HTTPS is turned on by providing a certificate we don't need any extra error checking.