### PR TITLE
Fix to prevent api key from being removed from the state file when the key is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.5.2 (February 18, 2025)
+## 2.5.2 (February 19, 2025)
 BUGFIX
 * Keep API key in state file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.2 (February 18, 2025)
+BUGFIX
+* Keep API key in state file
+
 ## 2.5.1 (February 5, 2025)
 ENHANCEMENTS
 * Allow underscore for non-HTTPS redirects

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.4.3"
+	clientVersion     = "2.4.4"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )

--- a/ns1/resource_apikey.go
+++ b/ns1/resource_apikey.go
@@ -59,11 +59,17 @@ func apikeyResource() *schema.Resource {
 func apikeyToResourceData(d *schema.ResourceData, k *account.APIKey) error {
 	d.SetId(k.ID)
 	d.Set("name", k.Name)
-	d.Set("key", k.Key)
 	d.Set("teams", k.TeamIDs)
 	d.Set("ip_whitelist", k.IPWhitelist)
 	d.Set("ip_whitelist_strict", k.IPWhitelistStrict)
 	permissionsToResourceData(d, k.Permissions)
+
+	// keep the existing key in the state file when there's no key in the response
+	d.Set("key", d.Get("key"))
+	if k.Key != "" {
+		d.Set("key", k.Key)
+	}
+
 	return nil
 }
 

--- a/ns1/resource_apikey.go
+++ b/ns1/resource_apikey.go
@@ -65,7 +65,6 @@ func apikeyToResourceData(d *schema.ResourceData, k *account.APIKey) error {
 	permissionsToResourceData(d, k.Permissions)
 
 	// keep the existing key in the state file when there's no key in the response
-	d.Set("key", d.Get("key"))
 	if k.Key != "" {
 		d.Set("key", k.Key)
 	}

--- a/website/docs/r/apikey.html.markdown
+++ b/website/docs/r/apikey.html.markdown
@@ -87,6 +87,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
+-> Imported keys will not have their key stored in the state file.
+
 `terraform import ns1_apikey`
 
 So for the example above:


### PR DESCRIPTION
Issue: https://github.com/ns1-terraform/terraform-provider-ns1/issues/340

API Keys are only visible on create, which means they get removed from the state file if they get updated at all due to the empty response for `key` on update.

This fix keeps the api key in the state file.