### PR TITLE
Deprecate usage on billing permission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-ns1
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/fatih/structs v1.1.0

--- a/ns1/resource_user.go
+++ b/ns1/resource_user.go
@@ -30,9 +30,11 @@ func userResource() *schema.Resource {
 			Required: true,
 		},
 		"notify": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Elem:     schema.TypeBool,
+			Deprecated: "This field is deprecated and will be removed in a future release; create account usage alerts instead.",
+			Type:       schema.TypeMap,
+			Optional:   true,
+			Computed:   true,
+			Elem:       schema.TypeBool,
 		},
 		"teams": {
 			Type:     schema.TypeList,
@@ -76,9 +78,6 @@ func userToResourceData(d *schema.ResourceData, u *account.User) error {
 	d.Set("name", u.Name)
 	d.Set("email", u.Email)
 	d.Set("teams", u.TeamIDs)
-	notify := make(map[string]bool)
-	notify["billing"] = u.Notify.Billing
-	d.Set("notify", notify)
 	d.Set("ip_whitelist", u.IPWhitelist)
 	d.Set("ip_whitelist_strict", u.IPWhitelistStrict)
 	permissionsToResourceData(d, u.Permissions)
@@ -97,10 +96,6 @@ func resourceDataToUser(u *account.User, d *schema.ResourceData) error {
 		}
 	} else {
 		u.TeamIDs = make([]string, 0)
-	}
-	if v, ok := d.GetOk("notify"); ok {
-		notifyRaw := v.(map[string]interface{})
-		u.Notify.Billing = notifyRaw["billing"].(bool)
 	}
 
 	if v, ok := d.GetOk("ip_whitelist"); ok {

--- a/ns1/resource_user_test.go
+++ b/ns1/resource_user_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"regexp"
 	"sort"
 	"testing"
 
@@ -36,7 +35,6 @@ func TestAccUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ns1_user.u", "name", name),
 					resource.TestCheckResourceAttr("ns1_user.u", "teams.#", "1"),
 					resource.TestCheckResourceAttr("ns1_user.u", "notify.%", "1"),
-					resource.TestCheckResourceAttr("ns1_user.u", "notify.billing", "true"),
 					resource.TestCheckResourceAttr("ns1_user.u", "username", username),
 					testAccCheckUserIPWhitelists(&user, []string{"1.1.1.1", "2.2.2.2"}),
 					resource.TestCheckResourceAttr("ns1_user.u", "ip_whitelist_strict", "true"),
@@ -50,7 +48,6 @@ func TestAccUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ns1_user.u", "name", name),
 					resource.TestCheckResourceAttr("ns1_user.u", "teams.#", "1"),
 					resource.TestCheckResourceAttr("ns1_user.u", "notify.%", "1"),
-					resource.TestCheckResourceAttr("ns1_user.u", "notify.billing", "true"),
 					resource.TestCheckResourceAttr("ns1_user.u", "username", username),
 					testAccCheckUserIPWhitelists(&user, []string{}),
 					resource.TestCheckResourceAttr("ns1_user.u", "ip_whitelist_strict", "false"),
@@ -80,13 +77,6 @@ func TestAccUser_ManualDelete(t *testing.T) {
 				Config:             testAccUserBasic(rString),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-			},
-			// Attempt to re-create it, this should fail because user names must be historically unique.
-			// Error: PUT https://api.nsone.net/v1/account/users: 409 login name tf_acc_test_user_k8qsnpxghuhgmip already exists
-
-			{
-				Config:      testAccUserBasic(rString),
-				ExpectError: regexp.MustCompile(`PUT .*/account/users.*already exists`),
 			},
 		},
 	})
@@ -459,7 +449,6 @@ func TestAccUser_import_test(t *testing.T) {
 					resource.TestCheckResourceAttr("ns1_user.u", "name", name),
 					resource.TestCheckResourceAttr("ns1_user.u", "teams.#", "1"),
 					resource.TestCheckResourceAttr("ns1_user.u", "notify.%", "1"),
-					resource.TestCheckResourceAttr("ns1_user.u", "notify.billing", "true"),
 					resource.TestCheckResourceAttr("ns1_user.u", "username", username),
 					testAccCheckUserIPWhitelists(&user, []string{"1.1.1.1", "2.2.2.2"}),
 					resource.TestCheckResourceAttr("ns1_user.u", "ip_whitelist_strict", "true"),
@@ -656,7 +645,7 @@ resource "ns1_user" "u" {
   email = "tf_acc_test_ns1@hashicorp.com"
   teams = ["${ns1_team.t.id}"]
   notify = {
-    billing = true
+    billing = false
   }
   ip_whitelist        = ["1.1.1.1", "2.2.2.2"]
   ip_whitelist_strict = true


### PR DESCRIPTION
With the introduction of usage alerts we are going to deprecate the notify on billing permission for users as it will eventually be removed from the NS1 connect APIs.