### PR TITLE
Fix issue with creating alerts without the data resource

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: v1.26.2
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,40 +5,40 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-    - freebsd
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - '386'
-    - arm
-    - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum
     args:
-      # if you are using this is a GitHub action or some other automated pipeline, you 
+      # if you are using this is a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
@@ -51,4 +51,4 @@ release:
   # Visit your project's GitHub Releases page to publish this release.
   draft: true
 changelog:
-  skip: true
+  disable: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.7.1 (September 26, 2025)
+BUGFIX
+* Fix issue with alert data that had made it mandatory by mistake
+
 ## 2.7.0 (September 5, 2025)
 ENHANCEMENTS
 * Adds support for new Alerts

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	clientVersion     = "2.7.0"
+	clientVersion     = "2.7.1"
 	providerUserAgent = "tf-ns1" + "/" + clientVersion
 	defaultRetryMax   = 3
 )

--- a/ns1/resource_alert.go
+++ b/ns1/resource_alert.go
@@ -107,7 +107,9 @@ func alertToResourceData(d *schema.ResourceData, alert *alerting.Alert) error {
 	d.Set("notification_lists", alert.NotifierListIds)
 	d.Set("zone_names", alert.ZoneNames)
 	d.Set("record_ids", alert.RecordIds)
-	if alert.Data != nil {
+	// a new resource can't be defined here apparently
+	// when trying to set data where it's not defined we get: set item just set doesn't exist
+	if _, ok := d.GetOk("data"); ok || string(alert.Data) != "{}" {
 		params := map[string]any{}
 		err := json.Unmarshal(alert.Data, &params)
 		if err != nil {

--- a/ns1/resource_alert_test.go
+++ b/ns1/resource_alert_test.go
@@ -390,6 +390,8 @@ resource "ns1_zone" "alert_zone_%d" {
   primary              = "192.0.2.1"
   additional_primaries = ["192.0.2.2"]
   additional_ports = [53]
+	additional_networks = [0]
+	additional_notify_only = [false]
 }`,
 			i, zoneNames[i])
 	}


### PR DESCRIPTION
Currently creating alerts without the data resource fails with a panic.
The cause seems to be that the resource cannot be created where it's not in the plan, so I'm going to ignore it when missing