### PR TITLE
fix: headers cannot be added to notifiers

### DIFF
--- a/ns1/resource_notifylist_test.go
+++ b/ns1/resource_notifylist_test.go
@@ -56,6 +56,13 @@ func TestAccNotifyList_updated(t *testing.T) {
 					testAccCheckNotifyListName(&nl, "terraform test"),
 				),
 			},
+			{
+				Config: testAccNotifyListUpdatedMultipleHeaders,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotifyListExists("ns1_notifylist.test", &nl),
+					testAccCheckNotifyListName(&nl, "terraform test"),
+				),
+			},
 		},
 	})
 }
@@ -261,10 +268,25 @@ resource "ns1_notifylist" "test" {
     type = "webhook"
     config = {
       url = "http://localhost:9091"
+			headers = "Content-Type: application/json"
     }
   }
 }
 `
+
+const testAccNotifyListUpdatedMultipleHeaders = `
+resource "ns1_notifylist" "test" {
+  name = "terraform test"
+  notifications {
+    type = "webhook"
+    config = {
+      url = "http://localhost:9091"
+			headers = "Accept: application/json\nContent-Type: application/json"
+    }
+  }
+}
+`
+
 const testAccNotifyListSlack = `
 resource "ns1_notifylist" "test_slack" {
   name = "terraform test slack"
@@ -278,6 +300,7 @@ resource "ns1_notifylist" "test_slack" {
   }
 }
 `
+
 const testAccNotifyListPagerDuty = `
 resource "ns1_notifylist" "test_pagerduty" {
   name = "terraform test pagerduty"

--- a/website/docs/r/notifylist.html.markdown
+++ b/website/docs/r/notifylist.html.markdown
@@ -19,6 +19,7 @@ resource "ns1_notifylist" "nl" {
     type = "webhook"
     config = {
       url = "http://www.mywebhook.com"
+      headers = "Content-Type: application/json"
     }
   }
 
@@ -40,8 +41,15 @@ The following arguments are supported:
 
 Notify List Notifiers (`notifications`) support the following:
 
-* `type` - (Required) The type of notifier. Available notifiers are indicated in /notifytypes endpoint. 
+* `type` - (Required) The type of notifier. Available notifiers are indicated in /notifytypes endpoint.
 * `config` - (Required) Configuration details for the given notifier type.
+  * `email` - Email to notify to; required for type = "email"
+  * `service_key` - Service key of the Pagerduty integration to notify to; required for type = "pagerduty"
+  * `sourceid` - Source id of the datafeedto notify to; required for type = "datafeed"
+  * `url` - URL to notify to; required for type = "webhook" and "slack"
+  * `username` - Username to notify as; required for type = "slack"
+  * `channel` - Channel to notify to; required for type = "slack"
+  * `headers` - Headers to add in the notification (optional for type = "webhook"): because they're encoded as a string, they have to be in alphabetical order and separated by carriage return, e.g. `"Accept: application/json\nContent-Type: application/json"`
 
 ## Attributes Reference
 


### PR DESCRIPTION
The implementation of webhook headers is not ideal, because all members of `config` are currently defined as strings.
Trying to be backwards compatible the most I can do is document the poor encoding.