### PR TITLE
Use dynamic time in billing usage examples

### DIFF
--- a/examples/billing_usage.tf
+++ b/examples/billing_usage.tf
@@ -1,11 +1,11 @@
 locals {
-  now           = timestamp()
-  now_unix      = provider["time"].rfc3339_parse(local.now).unix
-  cur_mon = formatdate("YYYY-MM", local.now)
-  begin_mon          = "${local.cur_mon}-01T00:00:00Z"
-  bmon_unix     = provider["time"].rfc3339_parse(local.begin_mon).unix
-  end_mon          = timeadd(local.begin_mon, "720h")
-  emon_unix     = provider["time"].rfc3339_parse(local.end_mon).unix
+  now       = timestamp()
+  now_unix  = provider["time"].rfc3339_parse(local.now).unix
+  cur_mon   = formatdate("YYYY-MM", local.now)
+  begin_mon = "${local.cur_mon}-01T00:00:00Z"
+  bmon_unix = provider["time"].rfc3339_parse(local.begin_mon).unix
+  end_mon   = timeadd(local.begin_mon, "720h")
+  emon_unix = provider["time"].rfc3339_parse(local.end_mon).unix
 }
 
 # Get query usage data for the given timeframe

--- a/ns1/examples/billing_usage.tf
+++ b/ns1/examples/billing_usage.tf
@@ -1,11 +1,11 @@
 locals {
-  now           = timestamp()
-  now_unix      = provider["time"].rfc3339_parse(local.now).unix
-  cur_mon = formatdate("YYYY-MM", local.now)
-  begin_mon          = "${local.cur_mon}-01T00:00:00Z"
-  bmon_unix     = provider["time"].rfc3339_parse(local.begin_mon).unix
-  end_mon          = timeadd(local.begin_mon, "720h")
-  emon_unix     = provider["time"].rfc3339_parse(local.end_mon).unix
+  now       = timestamp()
+  now_unix  = provider["time"].rfc3339_parse(local.now).unix
+  cur_mon   = formatdate("YYYY-MM", local.now)
+  begin_mon = "${local.cur_mon}-01T00:00:00Z"
+  bmon_unix = provider["time"].rfc3339_parse(local.begin_mon).unix
+  end_mon   = timeadd(local.begin_mon, "720h")
+  emon_unix = provider["time"].rfc3339_parse(local.end_mon).unix
 }
 
 # Get query usage data for the given timeframe

--- a/website/docs/d/billing_usage.html.markdown
+++ b/website/docs/d/billing_usage.html.markdown
@@ -16,13 +16,13 @@ The following example uses the provider `hashicorp/time` to select the times dyn
 
 ```hcl
 locals {
-  now           = timestamp()
-  now_unix      = provider["time"].rfc3339_parse(local.now).unix
-  cur_mon = formatdate("YYYY-MM", local.now)
-  begin_mon          = "${local.cur_mon}-01T00:00:00Z"
-  bmon_unix     = provider["time"].rfc3339_parse(local.begin_mon).unix
-  end_mon          = timeadd(local.begin_mon, "720h")
-  emon_unix     = provider["time"].rfc3339_parse(local.end_mon).unix
+  now       = timestamp()
+  now_unix  = provider["time"].rfc3339_parse(local.now).unix
+  cur_mon   = formatdate("YYYY-MM", local.now)
+  begin_mon = "${local.cur_mon}-01T00:00:00Z"
+  bmon_unix = provider["time"].rfc3339_parse(local.begin_mon).unix
+  end_mon   = timeadd(local.begin_mon, "720h")
+  emon_unix = provider["time"].rfc3339_parse(local.end_mon).unix
 }
 
 # Get query usage data for the given timeframe


### PR DESCRIPTION
Our documentation hard-codes the datetime in Terraform, so there are no references to how a customer should go about using dynamic time. Such references would be helpful to include for those unaware that Unix Epoch seconds are not the default units of measurement in Terraform.

One way that they could have dynamism is to use the Hashicorp `time` provider to convert timestamps to Unix epoch seconds.